### PR TITLE
Add option to build with rustls-tls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,17 @@ authors = [
   "sigstore-rs developers",
 ]
 
+[features]
+default = ["native-tls"]
+native-tls = ["oci-distribution/native-tls"]
+rustls-tls = ["oci-distribution/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 base64 = "0.13.0"
 ecdsa = { version = "0.12.4", features = ["verify", "pem", "der", "pkcs8"] }
-oci-distribution = "0.7.0"
+oci-distribution = { version = "0.7.0", default-features = false }
 olpc-cjson = "0.1.1"
 p256 = {version = "0.9.0", features = ["ecdsa-core"]}
 serde_json = "1.0.68"


### PR DESCRIPTION
#### Summary

Allow to choose the SSL backend. By default it's `native-tls`, but it can be set to `rustls-tls` in order to not depend on the OpenSSL stack of the system.

```release-note
Allow to choose the SSL stack by adding a `native-tls` or `rustls-tls` feature
```
