### PR TITLE
Make accept_invalid_hostnames conditional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.44"
 async-trait = "0.1.51"
 base64 = "0.13.0"
 ecdsa = { version = "0.12.4", features = ["verify", "pem", "der", "pkcs8"] }
-oci-distribution = { version = "0.7.0", default-features = false }
+oci-distribution = { version = "0.8.1", default-features = false }
 olpc-cjson = "0.1.1"
 p256 = {version = "0.9.0", features = ["ecdsa-core"]}
 serde_json = "1.0.68"

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -221,7 +221,7 @@ mod tests {
         let image = "docker.io/busybox:latest";
         let image_digest =
             String::from("sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b");
-        let expected_image = "docker.io/busybox:sha256-f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b.sig".parse().unwrap();
+        let expected_image = "docker.io/library/busybox:sha256-f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b.sig".parse().unwrap();
         let mock_client = MockOciClient {
             fetch_manifest_digest_response: Some(Ok(image_digest.clone())),
             pull_response: None,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -111,6 +111,7 @@ pub struct ClientConfig {
     pub protocol: ClientProtocol,
 
     /// Accept invalid hostname. Defaults to false
+    #[cfg(feature = "native-tls")]
     pub accept_invalid_hostnames: bool,
 
     /// Accept invalid certificates. Defaults to false
@@ -125,6 +126,7 @@ impl Default for ClientConfig {
     fn default() -> Self {
         ClientConfig {
             protocol: ClientProtocol::Https,
+            #[cfg(feature = "native-tls")]
             accept_invalid_hostnames: false,
             accept_invalid_certificates: false,
             extra_root_certificates: Vec::new(),
@@ -137,6 +139,7 @@ impl From<ClientConfig> for oci_distribution::client::ClientConfig {
         oci_distribution::client::ClientConfig {
             protocol: oci_distribution::client::ClientProtocol::Https,
             accept_invalid_certificates: config.accept_invalid_certificates,
+            #[cfg(feature = "native-tls")]
             accept_invalid_hostnames: config.accept_invalid_hostnames,
             extra_root_certificates: config
                 .extra_root_certificates


### PR DESCRIPTION
Depends on: https://github.com/sigstore/sigstore-rs/pull/13
Depends on a release of the `oci-distribution` crate that contains https://github.com/krustlet/oci-distribution/pull/8.

Make `accept_invalid_hostnames` optional, given it's only used in the `openssl` backend. When `oci-distribution` is released with the mentioned commit (ca1fc724308ed183b42b3239e49c1b23ef183524), the `accept_invalid_hostnames` will **only and only** exist in the struct if the chosen SSL backend is `openssl`.

Signed-off-by: Rafael Fernández López <ereslibre@ereslibre.es>