### PR TITLE
Better error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ native-tls = ["oci-distribution/native-tls"]
 rustls-tls = ["oci-distribution/rustls-tls"]
 
 [dependencies]
-anyhow = "1.0.44"
 async-trait = "0.1.51"
 base64 = "0.13.0"
 ecdsa = { version = "0.12.4", features = ["verify", "pem", "der", "pkcs8"] }
@@ -23,6 +22,7 @@ p256 = {version = "0.9.0", features = ["ecdsa-core"]}
 sha2 = "0.10.1"
 serde_json = "1.0.68"
 serde = {version = "1.0.130", features = ["derive"]}
+thiserror = "1.0.30"
 tokio = { version = "1.12.0", features = ["full"]}
 tough = { version = "0.12.1", features = [ "http" ] }
 tracing = "0.1.29"
@@ -30,6 +30,7 @@ url = "2.2.2"
 x509-parser = { version = "0.12.0", features = ["verify"]}
 
 [dev-dependencies]
+anyhow = "1.0.44"
 chrono = "0.4.19"
 clap = "2.33.3"
 openssl = "0.10.38"

--- a/src/cosign/client_builder.rs
+++ b/src/cosign/client_builder.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
 use tracing::info;
 
 use super::client::Client;
 use crate::crypto;
+use crate::errors::Result;
 use crate::registry::ClientConfig;
 
 /// A builder that generates Client objects.

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -48,10 +48,10 @@
 //! In case you want to mock sigstore interactions inside of your own code, you
 //! can implement the [`CosignCapabilities`] trait inside of your test suite.
 
-use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
+use crate::errors::Result;
 use crate::registry::Auth;
 use crate::simple_signing::SimpleSigning;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,102 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, SigstoreError>;
+
+#[derive(Error, Debug)]
+pub enum SigstoreError {
+    #[error("invalid key format: {error}")]
+    InvalidKeyFormat { error: String },
+
+    #[error(transparent)]
+    PEMParseError(#[from] x509_parser::nom::Err<x509_parser::error::PEMError>),
+
+    #[error(transparent)]
+    X509ParseError(#[from] x509_parser::nom::Err<x509_parser::error::X509Error>),
+
+    #[error(transparent)]
+    X509Error(#[from] x509_parser::error::X509Error),
+
+    #[error(transparent)]
+    Base64DecodeError(#[from] base64::DecodeError),
+
+    #[error(transparent)]
+    EcdsaError(#[from] ecdsa::Error),
+
+    #[error("Certificate validity check failed: cannot be used before {0}")]
+    CertificateValidityError(String),
+
+    #[error("Certificate has not been issued for {0}")]
+    CertificateInvalidEmail(String),
+
+    #[error("Certificate expired before signatures were entered in log: {integrated_time} is before {not_before}")]
+    CertificateExpiredBeforeSignaturesSubmittedToRekor {
+        integrated_time: String,
+        not_before: String,
+    },
+
+    #[error("Certificate was issued after signatures were entered in log: {integrated_time} is after {not_after}")]
+    CertificateIssuedAfterSignaturesSubmittedToRekor {
+        integrated_time: String,
+        not_after: String,
+    },
+
+    #[error("Bundled certificate does not have digital signature key usage")]
+    CertificateWithoutDigitalSignatureKeyUsage,
+
+    #[error("Bundled certificate does not have code signing extended key usage")]
+    CertificateWithoutCodeSigningKeyUsage,
+
+    #[error("Certificate without Subject Alternative Name")]
+    CertificateWithoutSubjectAlternativeName,
+
+    #[error("Cannot fetch manifest of {image}: {error}")]
+    RegistryFetchManifestError { image: String, error: String },
+
+    #[error("Cannot pull manifest of {image}: {error}")]
+    RegistryPullManifestError { image: String, error: String },
+
+    #[error("Cannot pull {image}: {error}")]
+    RegistryPullError { image: String, error: String },
+
+    #[error("OCI reference not valid: {reference}")]
+    OciReferenceNotValidError { reference: String },
+
+    #[error("Layer doesn't have Sigstore media type")]
+    SigstoreMediaTypeNotFoundError,
+
+    #[error("Layer digest mismatch")]
+    SigstoreLayerDigestMismatchError,
+
+    #[error("Missing signature annotation")]
+    SigstoreAnnotationNotFoundError,
+
+    #[error("Rekor bundle missing")]
+    SigstoreRekorBundleNotFoundError,
+
+    #[error(transparent)]
+    TufError(#[from] tough::error::Error),
+
+    #[error("TUF target {0} not found inside of repository")]
+    TufTargetNotFoundError(String),
+
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+
+    #[error("{0}")]
+    UnexpectedError(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ mod crypto;
 mod mock_client;
 
 pub mod cosign;
+pub mod errors;
 pub mod registry;
 pub mod simple_signing;
 pub mod tuf;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,7 +15,8 @@
 
 //! Set of structs and enums used to define how to interact with OCI registries
 
-use anyhow::Result;
+use crate::errors::{Result, SigstoreError};
+
 use async_trait::async_trait;
 use std::convert::From;
 
@@ -192,6 +193,10 @@ impl ClientCapabilities for OciClient {
         self.registry_client
             .fetch_manifest_digest(image, auth)
             .await
+            .map_err(|e| SigstoreError::RegistryFetchManifestError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
     }
 
     async fn pull(
@@ -203,6 +208,10 @@ impl ClientCapabilities for OciClient {
         self.registry_client
             .pull(image, auth, accepted_media_types)
             .await
+            .map_err(|e| SigstoreError::RegistryPullError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
     }
 
     async fn pull_manifest(
@@ -210,6 +219,12 @@ impl ClientCapabilities for OciClient {
         image: &oci_distribution::Reference,
         auth: &oci_distribution::secrets::RegistryAuth,
     ) -> Result<(oci_distribution::manifest::OciManifest, String)> {
-        self.registry_client.pull_manifest(image, auth).await
+        self.registry_client
+            .pull_manifest(image, auth)
+            .await
+            .map_err(|e| SigstoreError::RegistryPullManifestError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
     }
 }


### PR DESCRIPTION
Do not rely on `anyhow::Result` inside of public APIs. This makes error handling uglier for consumers of the library.

Instead, provide custom errors and use them inside of all the public facing APIs.
