### PR TITLE
 Big code refactoring: better handling of verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,11 @@ rustls-tls = ["oci-distribution/rustls-tls"]
 [dependencies]
 async-trait = "0.1.51"
 base64 = "0.13.0"
+der-parser = "6.0.1"
 ecdsa = { version = "0.12.4", features = ["verify", "pem", "der", "pkcs8"] }
-oci-distribution = { version = "0.8.1", default-features = false }
+# TODO: go back to the officially release oci-distribution once these patches are released
+#oci-distribution = { version = "0.8.1", default-features = false }
+oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "3e98fd5270016ffd01661f948769645ddf2bc026", default-features = false }
 olpc-cjson = "0.1.1"
 p256 = {version = "0.9.0", features = ["ecdsa-core"]}
 sha2 = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = [
   "sigstore-rs developers",

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ test: fmt lint
 .PHONY: clean
 clean:
 	cargo clean
+
+.PHONY: coverage
+coverage:
+	cargo tarpaulin -o Html

--- a/src/cosign/bundle.rs
+++ b/src/cosign/bundle.rs
@@ -22,7 +22,7 @@ use crate::errors::{Result, SigstoreError};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "PascalCase")]
-pub(crate) struct Bundle {
+pub struct Bundle {
     pub signed_entry_timestamp: String,
     pub payload: Payload,
 }
@@ -53,7 +53,7 @@ impl Bundle {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Payload {
+pub struct Payload {
     pub body: String,
     pub integrated_time: i64,
     pub log_index: i64,

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use std::collections::HashMap;
 use x509_parser::{traits::FromDer, x509::SubjectPublicKeyInfo};
 
 use super::{
@@ -25,7 +24,6 @@ use super::{
 use crate::crypto::CosignVerificationKey;
 use crate::errors::{Result, SigstoreError};
 use crate::registry::Auth;
-use crate::simple_signing::SimpleSigning;
 
 /// Cosign Client
 ///
@@ -34,7 +32,6 @@ pub struct Client {
     pub(crate) registry_client: Box<dyn crate::registry::ClientCapabilities>,
     pub(crate) rekor_pub_key: Option<CosignVerificationKey>,
     pub(crate) fulcio_pub_key_der: Option<Vec<u8>>,
-    pub(crate) cert_email: Option<String>,
 }
 
 #[async_trait]
@@ -67,15 +64,22 @@ impl CosignCapabilities for Client {
         Ok((reference, manifest_digest))
     }
 
-    async fn verify(
+    async fn trusted_signature_layers(
         &mut self,
         auth: &Auth,
         source_image_digest: &str,
         cosign_image: &str,
-        public_key: &Option<String>,
-        annotations: Option<HashMap<String, String>>,
-    ) -> Result<Vec<SimpleSigning>> {
+    ) -> Result<Vec<SignatureLayer>> {
         let (manifest, layers) = self.fetch_manifest_and_layers(auth, cosign_image).await?;
+        let image_manifest = match manifest {
+            oci_distribution::manifest::OciManifest::Image(im) => im,
+            oci_distribution::manifest::OciManifest::ImageIndex(_) => {
+                return Err(SigstoreError::RegistryPullManifestError {
+                    image: cosign_image.to_string(),
+                    error: "Found a OciImageIndex instead of a OciImageManifest".to_string(),
+                });
+            }
+        };
 
         let fulcio_pub_key = match &self.fulcio_pub_key_der {
             None => None,
@@ -85,26 +89,13 @@ impl CosignCapabilities for Client {
             }
         };
 
-        let verification_key: Option<CosignVerificationKey> = match public_key {
-            Some(key) => Some(crate::crypto::new_verification_key(key)?),
-            None => None,
-        };
-
-        let signature_layers = build_signature_layers(
-            &manifest,
+        build_signature_layers(
+            &image_manifest,
+            source_image_digest,
             &layers,
             self.rekor_pub_key.as_ref(),
             fulcio_pub_key.as_ref(),
-            self.cert_email.as_ref(),
-        );
-
-        let verified_signatures = self.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            source_image_digest,
-            verification_key.as_ref(),
-            &annotations.unwrap_or_default(),
-        );
-        Ok(verified_signatures)
+        )
     }
 }
 
@@ -142,50 +133,11 @@ impl Client {
 
         Ok((manifest, image_data.layers))
     }
-
-    /// The heart of the verification code. This is where all the checks are done
-    /// against the SignatureLayer objects found inside of the OCI registry.
-    ///
-    /// The method returns a list of SimpleSigning object satisfying the requirements.
-    /// The list is empty if no SimpleSigning object satisfied the requirements.
-    fn find_simple_signing_objects_satisfying_constraints(
-        &self,
-        signature_layers: &[SignatureLayer],
-        source_image_digest: &str,
-        verification_key: Option<&CosignVerificationKey>,
-        annotations: &HashMap<String, String>,
-    ) -> Vec<SimpleSigning> {
-        let verified_signatures: Vec<SimpleSigning> = signature_layers
-            .iter()
-            .filter_map(|sl| {
-                // find all the layers that have a signature that
-                // can be either verified with the supplied verification_key
-                // or with of the trusted bundled certificates.
-                // Then convert them into SimpleSigning objects
-                if sl.verified(verification_key) {
-                    Some(sl.simple_signing.clone())
-                } else {
-                    None
-                }
-            })
-            .filter(|ss| {
-                // ensure given annotations are respected
-                ss.satisfies_annotations(annotations)
-            })
-            .filter(|ss| {
-                // ensure the manifest digest mentioned by the signed SimpleSigning
-                // object matches the value of the OCI object we're verifying
-                ss.satisfies_manifest_digest(source_image_digest)
-            })
-            .collect();
-        verified_signatures
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cosign::signature_layers::tests::build_correct_signature_layer_without_bundle;
     use crate::cosign::tests::{FULCIO_CRT_PEM, REKOR_PUB_KEY};
     use crate::{
         crypto::{self},
@@ -199,7 +151,6 @@ mod tests {
             registry_client: Box::new(mock_client),
             rekor_pub_key: Some(rekor_pub_key),
             fulcio_pub_key_der: Some(FULCIO_CRT_PEM.as_bytes().to_vec()),
-            cert_email: None,
         }
     }
 
@@ -222,137 +173,5 @@ mod tests {
 
         assert!(reference.is_ok());
         assert_eq!(reference.unwrap(), (expected_image, image_digest));
-    }
-
-    #[test]
-    fn find_simple_signing_object_when_verification_key_and_no_annotations_are_provided() {
-        let (signature_layer, verification_key) = build_correct_signature_layer_without_bundle();
-        let source_image_digest = signature_layer
-            .simple_signing
-            .critical
-            .image
-            .docker_manifest_digest
-            .clone();
-        let signature_layers = vec![signature_layer];
-
-        let annotations: HashMap<String, String> = HashMap::new();
-
-        let mock_client = MockOciClient::default();
-        let cosign_client = build_test_client(mock_client);
-
-        let actual = cosign_client.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            &source_image_digest,
-            Some(&verification_key),
-            &annotations,
-        );
-        assert!(!actual.is_empty());
-    }
-
-    #[test]
-    fn find_simple_signing_object_no_matches_when_no_signature_matches_the_given_key() {
-        let (signature_layer, _) = build_correct_signature_layer_without_bundle();
-        let source_image_digest = signature_layer
-            .simple_signing
-            .critical
-            .image
-            .docker_manifest_digest
-            .clone();
-        let signature_layers = vec![signature_layer];
-
-        let verification_key = crate::crypto::new_verification_key(
-            r#"-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELKhD7F5OKy77Z582Y6h0u1J3GNA+
-kvUsh4eKpd1lwkDAzfFDs7yXEExsEkPPuiQJBelDT68n7PDIWB/QEY7mrA==
------END PUBLIC KEY-----"#,
-        )
-        .unwrap();
-
-        let annotations: HashMap<String, String> = HashMap::new();
-
-        let mock_client = MockOciClient::default();
-        let cosign_client = build_test_client(mock_client);
-
-        let actual = cosign_client.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            &source_image_digest,
-            Some(&verification_key),
-            &annotations,
-        );
-        assert!(actual.is_empty());
-    }
-
-    #[test]
-    fn find_simple_signing_object_no_matches_when_annotations_are_not_satisfied() {
-        let (signature_layer, verification_key) = build_correct_signature_layer_without_bundle();
-        let source_image_digest = signature_layer
-            .simple_signing
-            .critical
-            .image
-            .docker_manifest_digest
-            .clone();
-        let signature_layers = vec![signature_layer];
-
-        let mut annotations: HashMap<String, String> = HashMap::new();
-        annotations.insert("env".into(), "prod".into());
-
-        let mock_client = MockOciClient::default();
-        let cosign_client = build_test_client(mock_client);
-
-        let actual = cosign_client.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            &source_image_digest,
-            Some(&verification_key),
-            &annotations,
-        );
-        assert!(actual.is_empty());
-    }
-
-    #[test]
-    fn find_simple_signing_object_no_matches_when_simple_signing_digest_does_not_match_the_expected_one(
-    ) {
-        let (signature_layer, verification_key) = build_correct_signature_layer_without_bundle();
-        let source_image_digest = "this is a different value";
-        let signature_layers = vec![signature_layer];
-
-        let annotations: HashMap<String, String> = HashMap::new();
-
-        let mock_client = MockOciClient::default();
-        let cosign_client = build_test_client(mock_client);
-
-        let actual = cosign_client.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            &source_image_digest,
-            Some(&verification_key),
-            &annotations,
-        );
-        assert!(actual.is_empty());
-    }
-
-    #[test]
-    fn find_simple_signing_object_no_matches_when_no_signature_layer_exists() {
-        let source_image_digest = "something";
-        let signature_layers: Vec<SignatureLayer> = Vec::new();
-
-        let verification_key = crate::crypto::new_verification_key(
-            r#"-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELKhD7F5OKy77Z582Y6h0u1J3GNA+
-kvUsh4eKpd1lwkDAzfFDs7yXEExsEkPPuiQJBelDT68n7PDIWB/QEY7mrA==
------END PUBLIC KEY-----"#,
-        )
-        .unwrap();
-
-        let annotations: HashMap<String, String> = HashMap::new();
-
-        let mock_client = MockOciClient::default();
-        let cosign_client = build_test_client(mock_client);
-
-        let actual = cosign_client.find_simple_signing_objects_satisfying_constraints(
-            &signature_layers,
-            &source_image_digest,
-            Some(&verification_key),
-            &annotations,
-        );
-        assert!(actual.is_empty());
     }
 }

--- a/src/cosign/client_builder.rs
+++ b/src/cosign/client_builder.rs
@@ -42,7 +42,6 @@ pub struct ClientBuilder {
     oci_client_config: ClientConfig,
     rekor_pub_key: Option<String>,
     fulcio_cert: Option<Vec<u8>>,
-    cert_email: Option<String>,
 }
 
 impl ClientBuilder {
@@ -81,12 +80,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Optional: the email expected in a valid fulcio cert
-    pub fn with_cert_email(mut self, cert_email: Option<&str>) -> Self {
-        self.cert_email = cert_email.map(String::from);
-        self
-    }
-
     pub fn build(self) -> Result<Client> {
         let rekor_pub_key = match self.rekor_pub_key {
             None => {
@@ -104,8 +97,6 @@ impl ClientBuilder {
             Some(cert) => Some(crypto::extract_public_key_from_pem_cert(&cert)?),
         };
 
-        let cert_email = self.cert_email.clone();
-
         let oci_client =
             oci_distribution::client::Client::new(self.oci_client_config.clone().into());
         Ok(Client {
@@ -114,7 +105,6 @@ impl ClientBuilder {
             }),
             rekor_pub_key,
             fulcio_pub_key_der,
-            cert_email,
         })
     }
 }

--- a/src/cosign/constants.rs
+++ b/src/cosign/constants.rs
@@ -1,3 +1,22 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use der_parser::{oid, oid::Oid};
+
+pub(crate) const SIGSTORE_ISSUER_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .1);
+
 pub(crate) const SIGSTORE_OCI_MEDIA_TYPE: &str = "application/vnd.dev.cosign.simplesigning.v1+json";
 pub(crate) const SIGSTORE_SIGNATURE_ANNOTATION: &str = "dev.cosignproject.cosign/signature";
 pub(crate) const SIGSTORE_BUNDLE_ANNOTATION: &str = "dev.sigstore.cosign/bundle";

--- a/src/cosign/verification_constraint.rs
+++ b/src/cosign/verification_constraint.rs
@@ -1,0 +1,445 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs that can be used to verify [`crate::cosign::SignatureLayer`]
+//! with special business logic.
+//!
+//! This module provides already the most common kind of verification constraints:
+//! * [`PublicKeyVerifier`]: ensure a signature has been produced by a specific
+//!   cosign key
+//! * [`CertSubjectEmailVerifier`]: ensure a signature has been produced in keyless mode,
+//!   plus the email address associated with the signer matches a specific one
+//! * [`CertSubjectUrlVerifier`]: ensure a signature has been produced in keyless mode,
+//!   plus the certificate SAN has a specific URI inside of it. This can be used to verify
+//!   signatures produced by GitHub Actions.
+//!
+//! Developers can define ad-hoc validation logic by creating a Struct that implements
+//! the [`VerificationConstraintVec`] trait.
+
+use std::collections::HashMap;
+
+use super::signature_layers::{CertificateSubject, SignatureLayer};
+use crate::crypto::{self, CosignVerificationKey};
+use crate::errors::Result;
+
+/// A list of objects implementing the [`VerificationConstraint`] trait
+pub type VerificationConstraintVec = Vec<Box<dyn VerificationConstraint>>;
+
+/// A trait that can be used to define verification constraints objects
+/// that use a custom verification logic.
+pub trait VerificationConstraint: std::fmt::Debug {
+    /// Given the `signature_layer` object, return `true` if the verification
+    /// check is satisfied.
+    ///
+    /// Developer can use the
+    /// [`errors::SigstoreError::VerificationConstraintError`](crate::errors::SigstoreError::VerificationConstraintError)
+    /// error when something goes wrong inside of the verification logic.
+    ///
+    /// ```
+    /// use sigstore::{
+    ///   cosign::verification_constraint::VerificationConstraint,
+    ///   cosign::signature_layers::SignatureLayer,
+    ///   errors::{SigstoreError, Result},
+    /// };
+    ///
+    /// #[derive(Debug)]
+    /// struct MyVerifier{}
+    ///
+    /// impl VerificationConstraint for MyVerifier {
+    ///   fn verify(&self, _sl: &SignatureLayer) -> Result<bool> {
+    ///     Err(SigstoreError::VerificationConstraintError(
+    ///         "something went wrong!".to_string()))
+    ///   }
+    /// }
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool>;
+}
+
+/// Verification Constraint for signatures produced with public/private keys
+#[derive(Debug)]
+pub struct PublicKeyVerifier {
+    key: CosignVerificationKey,
+}
+
+impl PublicKeyVerifier {
+    /// Create a new instance of `PublicKeyVerifier`.
+    /// The `key_raw` variable holds a PEM encoded rapresentation of the
+    /// public key to be used at verification time.
+    pub fn new(key_raw: &str) -> Result<Self> {
+        let key = crypto::new_verification_key(key_raw)?;
+        Ok(PublicKeyVerifier { key })
+    }
+}
+
+impl VerificationConstraint for PublicKeyVerifier {
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool> {
+        Ok(signature_layer.is_signed_by_key(&self.key))
+    }
+}
+
+/// Verification Constraint for signatures produced in keyless mode.
+///
+/// Keyless signatures have a x509 certificate associated to them. This
+/// verifier ensures the SAN portion of the certificate has an email
+/// attribute that matches the one provided by the user.
+///
+/// It's also possible to specify the `Issuer`, this is the name of the
+/// identity provider that was used by the user to authenticate.
+///
+/// For example, `cosign` produces the following signature when the user
+/// relies on GitHub to authenticate himself:
+///
+/// ```hcl
+/// {
+///   "critical": {
+///      // not relevant
+///   },
+///   "optional": {
+///     "Bundle": {
+///       // not relevant
+///     },
+///     "Issuer": "https://github.com/login/oauth",
+///     "Subject": "alice@example.com"
+///   }
+/// }
+/// ```
+///
+/// The following constraints would be able to enforce this signature to be
+/// found:
+///
+/// ```rust
+/// use sigstore::cosign::verification_constraint::CertSubjectEmailVerifier;
+///
+/// // This looks only for the email address of the trusted user
+/// let vc_email = CertSubjectEmailVerifier{
+///     email: String::from("alice@example.com"),
+///     ..Default::default()
+/// };
+///
+/// // This ensures the user authenticated via GitHub (see the issuer value),
+/// // plus the email associated to his GitHub account must be the one specified.
+/// let vc_email_and_issuer = CertSubjectEmailVerifier{
+///     email: String::from("alice@example.com"),
+///     issuer: Some(String::from("https://github.com/login/oauth")),
+/// };
+/// ```
+///
+/// When `issuer` is `None`, the value found inside of the signature's certificate
+/// is not checked.
+///
+/// For example, given the following constraint:
+/// ```rust
+/// use sigstore::cosign::verification_constraint::CertSubjectEmailVerifier;
+///
+/// let constraint = CertSubjectEmailVerifier{
+///     email: String::from("alice@example.com"),
+///     ..Default::default()
+/// };
+/// ```
+///
+/// Both these signatures would be trusted:
+/// ```hcl
+/// [
+///   {
+///     "critical": {
+///        // not relevant
+///     },
+///     "optional": {
+///       "Bundle": {
+///         // not relevant
+///       },
+///       "Issuer": "https://github.com/login/oauth",
+///       "Subject": "alice@example.com"
+///     }
+///   },
+///   {
+///     "critical": {
+///        // not relevant
+///     },
+///     "optional": {
+///       "Bundle": {
+///         // not relevant
+///       },
+///       "Issuer": "https://example.com/login/oauth",
+///       "Subject": "alice@example.com"
+///     }
+///   }
+/// ]
+/// ```
+#[derive(Default, Debug)]
+pub struct CertSubjectEmailVerifier {
+    pub email: String,
+    pub issuer: Option<String>,
+}
+
+impl VerificationConstraint for CertSubjectEmailVerifier {
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool> {
+        let verified = match &signature_layer.certificate_signature {
+            Some(signature) => {
+                let email_matches = match &signature.subject {
+                    CertificateSubject::Email(e) => e == &self.email,
+                    _ => false,
+                };
+
+                let issuer_matches = match self.issuer {
+                    Some(_) => self.issuer == signature.issuer,
+                    None => true,
+                };
+
+                email_matches && issuer_matches
+            }
+            _ => false,
+        };
+        Ok(verified)
+    }
+}
+
+/// Verification Constraint for signatures produced in keyless mode.
+///
+/// Keyless signatures have a x509 certificate associated to them. This
+/// verifier ensures the SAN portion of the certificate has a URI
+/// attribute that matches the one provided by the user.
+///
+/// The constraints needs also the `Issuer` to be provided, this is the name
+/// of the identity provider that was used by the user to authenticate.
+///
+/// This verifier can be used to check keyless signatures produced in
+/// non-interactive mode inside of GitHub Actions.
+///
+/// For example, `cosign` produces the following signature when the
+/// OIDC token is extracted from the GITHUB_TOKEN:
+///
+/// ```hcl
+/// {
+///   "critical": {
+///     // not relevant
+///   },
+///   "optional": {
+///     "Bundle": {
+///     // not relevant
+///     },
+///     "Issuer": "https://token.actions.githubusercontent.com",
+///     "Subject": "https://github.com/flavio/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main"
+///   }
+/// }
+/// ```
+///
+/// The following constraint would be able to enforce this signature to be
+/// found:
+///
+/// ```rust
+/// use sigstore::cosign::verification_constraint::CertSubjectUrlVerifier;
+///
+/// let vc = CertSubjectUrlVerifier{
+///     url: String::from("https://github.com/flavio/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main"),
+///     issuer: String::from("https://token.actions.githubusercontent.com"),
+/// };
+/// ```
+#[derive(Default, Debug)]
+pub struct CertSubjectUrlVerifier {
+    pub url: String,
+    pub issuer: String,
+}
+
+impl VerificationConstraint for CertSubjectUrlVerifier {
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool> {
+        let verified = match &signature_layer.certificate_signature {
+            Some(signature) => {
+                let url_matches = match &signature.subject {
+                    CertificateSubject::Uri(u) => u == &self.url,
+                    _ => false,
+                };
+                let issuer_matches = Some(self.issuer.clone()) == signature.issuer;
+
+                url_matches && issuer_matches
+            }
+            _ => false,
+        };
+        Ok(verified)
+    }
+}
+
+/// Verification Constraint for the annotations added by `cosign sign`
+///
+/// The `SimpleSigning` object produced at signature time can be enriched by
+/// signer with so called "anntoations".
+///
+/// This constraint ensures that all the annotations specified by the user are
+/// found inside of the SignatureLayer.
+///
+/// It's perfectly find for the SignatureLayer to have additional annotations.
+/// These will be simply be ignored by the verifier.
+#[derive(Default, Debug)]
+pub struct AnnotationVerifier {
+    pub annotations: HashMap<String, String>,
+}
+
+impl VerificationConstraint for AnnotationVerifier {
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool> {
+        let verified = signature_layer
+            .simple_signing
+            .satisfies_annotations(&self.annotations);
+        Ok(verified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cosign::signature_layers::tests::{
+        build_correct_signature_layer_with_certificate,
+        build_correct_signature_layer_without_bundle,
+    };
+    use crate::cosign::signature_layers::CertificateSubject;
+
+    #[test]
+    fn pub_key_verifier() {
+        let (sl, key) = build_correct_signature_layer_without_bundle();
+
+        let vc = PublicKeyVerifier { key };
+        assert!(vc.verify(&sl).unwrap());
+
+        let sl = build_correct_signature_layer_with_certificate();
+        assert!(!vc.verify(&sl).unwrap());
+    }
+
+    #[test]
+    fn cert_email_verifier_only_email() {
+        let email = "alice@example.com".to_string();
+        let mut sl = build_correct_signature_layer_with_certificate();
+        let mut cert_signature = sl.certificate_signature.unwrap();
+        let cert_subj = CertificateSubject::Email(email.clone());
+        cert_signature.issuer = None;
+        cert_signature.subject = cert_subj;
+        sl.certificate_signature = Some(cert_signature);
+
+        let vc = CertSubjectEmailVerifier {
+            email,
+            issuer: None,
+        };
+        assert!(vc.verify(&sl).unwrap());
+
+        let vc = CertSubjectEmailVerifier {
+            email: "different@email.com".to_string(),
+            issuer: None,
+        };
+        assert!(!vc.verify(&sl).unwrap());
+    }
+
+    #[test]
+    fn cert_email_verifier_email_and_issuer() {
+        let email = "alice@example.com".to_string();
+        let mut sl = build_correct_signature_layer_with_certificate();
+        let mut cert_signature = sl.certificate_signature.unwrap();
+
+        // The cerificate subject doesn't have an issuer
+        let cert_subj = CertificateSubject::Email(email.clone());
+        cert_signature.issuer = None;
+        cert_signature.subject = cert_subj;
+        sl.certificate_signature = Some(cert_signature.clone());
+
+        // fail because the issuer we want doesn't exist
+        let vc = CertSubjectEmailVerifier {
+            email: email.clone(),
+            issuer: Some("an issuer".to_string()),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+
+        // The cerificate subject has an issuer
+        let issuer = "the issuer".to_string();
+        let cert_subj = CertificateSubject::Email(email.clone());
+        cert_signature.issuer = Some(issuer.clone());
+        cert_signature.subject = cert_subj;
+        sl.certificate_signature = Some(cert_signature);
+
+        let vc = CertSubjectEmailVerifier {
+            email: email.clone(),
+            issuer: Some(issuer.clone()),
+        };
+        assert!(vc.verify(&sl).unwrap());
+
+        let vc = CertSubjectEmailVerifier {
+            email,
+            issuer: Some("another issuer".to_string()),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+
+        // another verifier should fail
+        let vc = CertSubjectUrlVerifier {
+            url: "https://sigstore.dev/test".to_string(),
+            issuer,
+        };
+        assert!(!vc.verify(&sl).unwrap());
+    }
+
+    #[test]
+    fn cert_email_verifier_no_signature() {
+        let (sl, _) = build_correct_signature_layer_without_bundle();
+
+        let vc = CertSubjectEmailVerifier {
+            email: "alice@example.com".to_string(),
+            issuer: None,
+        };
+        assert!(!vc.verify(&sl).unwrap());
+    }
+
+    #[test]
+    fn cert_subject_url_verifier() {
+        let url = "https://sigstore.dev/test".to_string();
+        let issuer = "the issuer".to_string();
+
+        let mut sl = build_correct_signature_layer_with_certificate();
+        let mut cert_signature = sl.certificate_signature.unwrap();
+        let cert_subj = CertificateSubject::Uri(url.clone());
+        cert_signature.issuer = Some(issuer.clone());
+        cert_signature.subject = cert_subj;
+        sl.certificate_signature = Some(cert_signature);
+
+        let vc = CertSubjectUrlVerifier {
+            url: url.clone(),
+            issuer: issuer.clone(),
+        };
+        assert!(vc.verify(&sl).unwrap());
+
+        let vc = CertSubjectUrlVerifier {
+            url: "a different url".to_string(),
+            issuer: issuer.clone(),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+
+        let vc = CertSubjectUrlVerifier {
+            url,
+            issuer: "a different issuer".to_string(),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+
+        // A Cert email verifier should also report a non match
+        let vc = CertSubjectEmailVerifier {
+            email: "alice@example.com".to_string(),
+            issuer: Some(issuer),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+    }
+
+    #[test]
+    fn cert_subject_verifier_no_signature() {
+        let (sl, _) = build_correct_signature_layer_without_bundle();
+
+        let vc = CertSubjectUrlVerifier {
+            url: "https://sigstore.dev/test".to_string(),
+            issuer: "an issuer".to_string(),
+        };
+        assert!(!vc.verify(&sl).unwrap());
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! The errors that can be raised by sigstore-rs
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, SigstoreError>;
@@ -64,6 +66,9 @@ pub enum SigstoreError {
     #[error("Certificate without Subject Alternative Name")]
     CertificateWithoutSubjectAlternativeName,
 
+    #[error("Certificate with incomplete Subject Alternative Name")]
+    CertificateWithIncompleteSubjectAlternativeName,
+
     #[error("Cannot fetch manifest of {image}: {error}")]
     RegistryFetchManifestError { image: String, error: String },
 
@@ -88,6 +93,12 @@ pub enum SigstoreError {
     #[error("Rekor bundle missing")]
     SigstoreRekorBundleNotFoundError,
 
+    #[error("Fulcio public key not provided")]
+    SigstoreFulcioPublicNotProvidedError,
+
+    #[error("No Signature Layer passed verification")]
+    SigstoreNoVerifiedLayer,
+
     #[error(transparent)]
     TufError(#[from] tough::error::Error),
 
@@ -99,4 +110,7 @@ pub enum SigstoreError {
 
     #[error("{0}")]
     UnexpectedError(String),
+
+    #[error("{0}")]
+    VerificationConstraintError(String),
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -147,6 +147,7 @@ impl From<ClientConfig> for oci_distribution::client::ClientConfig {
                 .iter()
                 .map(|c| c.into())
                 .collect(),
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
First of all, sorry about the large amount of changes... Unfortunately the old code was too limited as we realized when using that inside of Kubewarden.

Prior to this commit:

* The email used to verify a keyless signature had to be specified inside of the `ClientBuilder`. That meant that, to verify the presence of multiple emails, multiple clients had to be created. That was a poor UX
* The library didn't parse some important data provided by the signature certificates: the URI and the OIDC issuer. These are required to build more flexible verification checks

In addition to addressing the previous limitations, this commit introduces the following changes:

* It's possible to define a series of Verification Constraints, which allows multiple requirements can be enforced against the list of signature layers of an image
* End users can develop their own Verification Constraints, and feed them to the usual verification API to enforce them
* Not finding any trusted layer now raises a dedicated error. This fixes issue #18
