### PR TITLE
Update oci-distribution revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ der-parser = "6.0.1"
 ecdsa = { version = "0.12.4", features = ["verify", "pem", "der", "pkcs8"] }
 # TODO: go back to the officially release oci-distribution once these patches are released
 #oci-distribution = { version = "0.8.1", default-features = false }
-oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "3e98fd5270016ffd01661f948769645ddf2bc026", default-features = false }
+oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "0f717968093a5415f428503d741dedf24ea97948", default-features = false }
 olpc-cjson = "0.1.1"
 p256 = {version = "0.9.0", features = ["ecdsa-core"]}
 sha2 = "0.10.1"


### PR DESCRIPTION
Ensure we get a fix that just got merged on the main branch, this is needed to properly build with rustls.