### PR TITLE
Create GH action to auto publish crate upon release

### DIFF
--- a/.github/workflows/auto-publish-crates-upon-release.yml
+++ b/.github/workflows/auto-publish-crates-upon-release.yml
@@ -14,6 +14,4 @@ jobs:
            override: true
 
       - name: publish crates
-        uses: katyo/publish-crates@v1
-        with: 
-          registry-token: ${{ secrets.CARGO_API_TOKEN }}
+        run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}

--- a/.github/workflows/auto-publish-crates-upon-release.yml
+++ b/.github/workflows/auto-publish-crates-upon-release.yml
@@ -1,0 +1,19 @@
+name: Publish-Crate-Upon-Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-automatically:
+    runs-on: ubuntu-latest
+    steps:
+      -  uses: actions/checkout@v2
+      -  uses: actions-rs/toolchain@v1
+         with:
+           toolchain: stable
+           override: true
+
+      - name: publish crates
+        uses: katyo/publish-crates@v1
+        with: 
+          registry-token: ${{ secrets.CARGO_API_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Creates a Github action to automatically `cargo publish` each new release to crates.io.
The version number of the crate in the Cargo.toml file will have to be updated prior to the new release for the action to work.
Also, a Github secret for the crates.io API token needs to be set up so that there's authorization to publish the update. Currently, the secret is named CARGO_API_TOKEN in the .yml file.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

-->
Fixes #30 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
