### PR TITLE
Change the visibility of `SignagureLayer` attributes

### DIFF
--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -99,9 +99,9 @@ pub struct SignatureLayer {
     /// The bundle produced by Rekor.
     pub bundle: Option<Bundle>,
     #[serde(skip_serializing)]
-    signature: String,
+    pub signature: String,
     #[serde(skip_serializing)]
-    raw_data: Vec<u8>,
+    pub raw_data: Vec<u8>,
 }
 
 impl fmt::Display for SignatureLayer {


### PR DESCRIPTION
This is required to make writing of unit tests easier for 3rd parties defining their own constraint validators.

