### PR TITLE
fix: cosign::filter_signature_layers() when no match 

### DIFF
--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -275,10 +275,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 
         let error =
             filter_signature_layers(&layers, constraints).expect_err("Should have got an error");
-        let found = match error {
-            SigstoreError::SigstoreNoVerifiedLayer => true,
-            _ => false,
-        };
+        let found = matches!(error, SigstoreError::SigstoreNoVerifiedLayer);
         assert!(found, "Didn't get the expected error, got {}", error);
     }
 }

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -233,10 +233,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
     fn filter_signature_layers_no_matches() {
         let email = "alice@example.com".to_string();
         let issuer = "an issuer".to_string();
-
-        let mut annotations: HashMap<String, String> = HashMap::new();
-        annotations.insert("key1".into(), "value1".into());
-        annotations.insert("key2".into(), "value2".into());
+        let email_constraint = "bob@example.com".to_string();
 
         let mut layers: Vec<SignatureLayer> = Vec::new();
         let expected_matches = 5;
@@ -265,22 +262,19 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 
         let mut constraints: VerificationConstraintVec = Vec::new();
         let vc = CertSubjectEmailVerifier {
-            email: email.clone(),
+            email: email_constraint.clone(),
             issuer: Some(issuer.clone()),
         };
         constraints.push(Box::new(vc));
 
         let vc = CertSubjectEmailVerifier {
-            email: email.clone(),
+            email: email_constraint.clone(),
             issuer: None,
         };
         constraints.push(Box::new(vc));
 
-        let vc = AnnotationVerifier { annotations };
-        constraints.push(Box::new(vc));
-
         let error =
-            filter_signature_layers(&layers, constraints).expect_err("Should have god an error");
+            filter_signature_layers(&layers, constraints).expect_err("Should have got an error");
         let found = match error {
             SigstoreError::SigstoreNoVerifiedLayer => true,
             _ => false,

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -101,9 +101,9 @@ pub fn filter_signature_layers(
                 let is_a_match = if constraints.is_empty() {
                     true
                 } else {
-                    !constraints.iter().any(|c| {
+                    constraints.iter().any(|c| {
                         match c.verify(sl) {
-                            Ok(verification_passed) => !verification_passed,
+                            Ok(verification_passed) => verification_passed,
                             Err(e) => {
                                 warn!(error = ?e, constraint = ?c, "Skipping layer because constraint verification returned an error");
                                 // handle errors as verification failures


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Remove negation inside of the `match` for constraints. This means that verified layers will get correctly passed to `any()`.

Remove negation on the `constraints.iter.any()`. this means that when a layer is verified (returning true in the closure), it well get added correctly to the layers vector.

All in all, this gives us the correct behaviour: if there's some verified signatures, they get added.
If there's no verified signatures, we return `SigstoreError::SigstoreNoVerifiedLayer`. In the past, we where almost always returning that error instead.

Fix test for correct behaviour.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
- fx: `cosign::filter_signature_layers()` when no match
```
