### PR TITLE
fix!: Drop filter_signature_layers() for verify_constraints() 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@ fmt:
 lint:
 	cargo clippy -- -D warnings
 
+.PHONY: doc
+doc:
+	cargo doc
+
 .PHONY: test
-test: fmt lint
+test: fmt lint doc
 	cargo test --workspace
 
 .PHONY: clean

--- a/examples/verify/main.rs
+++ b/examples/verify/main.rs
@@ -16,7 +16,7 @@
 extern crate sigstore;
 use sigstore::cosign::verification_constraint::{
     AnnotationVerifier, CertSubjectEmailVerifier, CertSubjectUrlVerifier, PublicKeyVerifier,
-    VerificationConstraint, VerificationConstraintVec,
+    VerificationConstraintVec,
 };
 use sigstore::cosign::{CosignCapabilities, SignatureLayer};
 use sigstore::crypto::SignatureDigestAlgorithm;
@@ -93,7 +93,7 @@ struct Cli {
     image: String,
 }
 
-async fn run_app() -> anyhow::Result<(Vec<SignatureLayer>, Vec<Box<dyn VerificationConstraint>>)> {
+async fn run_app() -> anyhow::Result<(Vec<SignatureLayer>, VerificationConstraintVec)> {
     let cli = Cli::parse();
 
     // Note well: this a limitation deliberately introduced by this example.

--- a/examples/verify/main.rs
+++ b/examples/verify/main.rs
@@ -232,7 +232,7 @@ pub async fn main() {
                 0
             } else {
                 eprintln!("Image verification failed: not all constraints satisfied.");
-                // serde_json::to_writer_pretty(std::io::stdout(), &unsatisfied_constraints).unwrap();
+                println!("{:?}", unsatisfied_constraints);
                 1
             }
         }

--- a/examples/verify/main.rs
+++ b/examples/verify/main.rs
@@ -16,10 +16,11 @@
 extern crate sigstore;
 use sigstore::cosign::verification_constraint::{
     AnnotationVerifier, CertSubjectEmailVerifier, CertSubjectUrlVerifier, PublicKeyVerifier,
-    VerificationConstraintVec,
+    VerificationConstraint, VerificationConstraintVec,
 };
-use sigstore::cosign::CosignCapabilities;
+use sigstore::cosign::{CosignCapabilities, SignatureLayer};
 use sigstore::crypto::SignatureDigestAlgorithm;
+use sigstore::errors::SigstoreVerifyConstraintsError;
 use sigstore::tuf::SigstoreRepository;
 use std::boxed::Box;
 use std::convert::TryFrom;
@@ -92,7 +93,7 @@ struct Cli {
     image: String,
 }
 
-async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
+async fn run_app() -> anyhow::Result<(Vec<SignatureLayer>, Vec<Box<dyn VerificationConstraint>>)> {
     let cli = Cli::parse();
 
     // Note well: this a limitation deliberately introduced by this example.
@@ -161,11 +162,11 @@ async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
     let mut client = client_builder.build()?;
 
     // Build verification constraints
-    let mut verification_constraint: VerificationConstraintVec = Vec::new();
+    let mut verification_constraints: VerificationConstraintVec = Vec::new();
     if let Some(cert_email) = cli.cert_email {
         let issuer = cli.cert_issuer.as_ref().map(|i| i.to_string());
 
-        verification_constraint.push(Box::new(CertSubjectEmailVerifier {
+        verification_constraints.push(Box::new(CertSubjectEmailVerifier {
             email: cert_email.to_string(),
             issuer,
         }));
@@ -178,7 +179,7 @@ async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
             ));
         }
 
-        verification_constraint.push(Box::new(CertSubjectUrlVerifier {
+        verification_constraints.push(Box::new(CertSubjectUrlVerifier {
             url: cert_url.to_string(),
             issuer: issuer.unwrap(),
         }));
@@ -190,13 +191,13 @@ async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
                 .map_err(anyhow::Error::msg)?;
         let verifier = PublicKeyVerifier::new(&key, signature_digest_algorithm)
             .map_err(|e| anyhow!("Cannot create public key verifier: {}", e))?;
-        verification_constraint.push(Box::new(verifier));
+        verification_constraints.push(Box::new(verifier));
     }
 
     if !cli.annotations.is_empty() {
         let mut values: HashMap<String, String> = HashMap::new();
         for annotation in &cli.annotations {
-            let tmp: Vec<_> = annotation.splitn(2, "=").collect();
+            let tmp: Vec<_> = annotation.splitn(2, '=').collect();
             if tmp.len() == 2 {
                 values.insert(String::from(tmp[0]), String::from(tmp[1]));
             }
@@ -205,7 +206,7 @@ async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
             let annotations_verifier = AnnotationVerifier {
                 annotations: values,
             };
-            verification_constraint.push(Box::new(annotations_verifier));
+            verification_constraints.push(Box::new(annotations_verifier));
         }
     }
 
@@ -217,23 +218,29 @@ async fn run_app() -> anyhow::Result<VerificationConstraintVec> {
         .trusted_signature_layers(auth, &source_image_digest, &cosign_signature_image)
         .await?;
 
-    sigstore::cosign::filter_constraints(&trusted_layers, verification_constraint)
-        .map_err(|e| anyhow!("{}", e))
+    Ok((trusted_layers, verification_constraints))
 }
 
 #[tokio::main]
 pub async fn main() {
-    let unsatisfied_constraints: anyhow::Result<VerificationConstraintVec> = run_app().await;
-
-    std::process::exit(match unsatisfied_constraints {
-        Ok(unsatisfied_constraints) => {
-            if unsatisfied_constraints.is_empty() {
-                println!("Image successfully verified");
-                0
-            } else {
-                eprintln!("Image verification failed: not all constraints satisfied.");
-                println!("{:?}", unsatisfied_constraints);
-                1
+    std::process::exit(match run_app().await {
+        Ok((trusted_layers, verification_constraints)) => {
+            let filter_result = sigstore::cosign::verify_constraints(
+                &trusted_layers,
+                verification_constraints.iter(),
+            );
+            match filter_result {
+                Ok(()) => {
+                    println!("Image successfully verified");
+                    0
+                }
+                Err(SigstoreVerifyConstraintsError {
+                    unsatisfied_constraints,
+                }) => {
+                    eprintln!("Image verification failed: not all constraints satisfied.");
+                    eprintln!("{:?}", unsatisfied_constraints);
+                    1
+                }
             }
         }
         Err(err) => {

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -53,7 +53,7 @@ impl CosignCapabilities for Client {
             "{}/{}:{}.sig",
             image_reference.registry(),
             image_reference.repository(),
-            manifest_digest.replace(":", "-")
+            manifest_digest.replace(':', "-")
         );
         let reference = sign
             .parse()

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -52,9 +52,9 @@ pub use self::client::Client;
 
 pub mod client_builder;
 pub use self::client_builder::ClientBuilder;
-use self::verification_constraint::VerificationConstraint;
 
 pub mod verification_constraint;
+use self::verification_constraint::{VerificationConstraint, VerificationConstraintRefVec};
 
 #[async_trait]
 /// Cosign Abilities that have to be implemented by a
@@ -108,7 +108,7 @@ pub fn verify_constraints<'a, 'b, I>(
 where
     I: Iterator<Item = &'b Box<dyn VerificationConstraint>>,
 {
-    let unsatisfied_constraints: Vec<&Box<dyn VerificationConstraint>> = constraints.filter(|c| {
+    let unsatisfied_constraints: VerificationConstraintRefVec = constraints.filter(|c| {
         let mut is_c_unsatisfied = true;
         signature_layers.iter().any( | sl | {
             // iterate through all layers and find if at least one layer
@@ -128,6 +128,7 @@ where
         });
         is_c_unsatisfied // if true, constraint gets filtered into result
     }).collect();
+
     if unsatisfied_constraints.is_empty() {
         Ok(())
     } else {
@@ -280,7 +281,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 
         let vc = CertSubjectEmailVerifier {
             email: wrong_email,
-            issuer: None, // missing issuer
+            issuer: None, // missing issuer, more relaxed
         };
         constraints.push(Box::new(vc));
 

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -76,8 +76,9 @@ pub trait CosignCapabilities {
     /// signature image. All the Bundled objects have been verified using Rekor's
     /// signature.
     ///
-    /// These returned objects can then be filtered using the [`filter_signature_layers`]
-    /// function.
+    /// These returned objects can then be verified against
+    /// [`VerificationConstraints`](crate::cosign::verification_constraint::VerificationConstraint)
+    /// using the [`verify_constraints`] function.
     async fn trusted_signature_layers(
         &mut self,
         auth: &Auth,
@@ -94,9 +95,9 @@ pub trait CosignCapabilities {
 /// If there's no unsatisfied constraints it means that the image passed
 /// verification.
 ///
-/// Returns a Result with either Ok() for passed verification or
-/// SigstoreError::SigstoreVerifyConstraintsError{}, which contains a vec of
-/// references to unsatisfied constraints.
+/// Returns a `Result` with either `Ok()` for passed verification or
+/// [`SigstoreVerifyConstraintsError`](crate::errors::SigstoreVerifyConstraintsError),
+/// which contains a vector of references to unsatisfied constraints.
 ///
 /// See the documentation of the [`cosign::verification_constraint`](crate::cosign::verification_constraint) module for more
 /// details about how to define verification constraints.

--- a/src/cosign/verification_constraint.rs
+++ b/src/cosign/verification_constraint.rs
@@ -37,6 +37,9 @@ use crate::errors::Result;
 /// A list of objects implementing the [`VerificationConstraint`] trait
 pub type VerificationConstraintVec = Vec<Box<dyn VerificationConstraint>>;
 
+/// A list of references to objects implementing the [`VerificationConstraint`] trait
+pub type VerificationConstraintRefVec<'a> = Vec<&'a Box<dyn VerificationConstraint>>;
+
 /// A trait that can be used to define verification constraints objects
 /// that use a custom verification logic.
 pub trait VerificationConstraint: std::fmt::Debug {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,14 @@
 
 use thiserror::Error;
 
+use crate::cosign::verification_constraint::VerificationConstraintRefVec;
+
+#[derive(Error, Debug)]
+#[error("Several Signature Layers failed verification")]
+pub struct SigstoreVerifyConstraintsError<'a> {
+    pub unsatisfied_constraints: VerificationConstraintRefVec<'a>,
+}
+
 pub type Result<T> = std::result::Result<T, SigstoreError>;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! ```rust,no_run
 //! use crate::sigstore::cosign::{
 //!     CosignCapabilities,
-//!     filter_constraints,
+//!     verify_constraints,
 //! };
 //! use crate::sigstore::cosign::verification_constraint::{
 //!     AnnotationVerifier,
@@ -70,6 +70,7 @@
 //! };
 //! use crate::sigstore::crypto::SignatureDigestAlgorithm;
 //! use crate::sigstore::errors::SigstoreError;
+//! use sigstore::errors::SigstoreVerifyConstraintsError;
 //!
 //! use std::boxed::Box;
 //! use std::collections::HashMap;
@@ -126,25 +127,24 @@
 //!
 //!   // Filter the constraints, find the ones not satisfied by the layers on
 //!   // the image
-//!   let unsatisfied_constraints = filter_constraints(
+//!   let result = verify_constraints(
 //!     &signature_layers,
-//!     verification_constraints);
+//!     verification_constraints.iter());
 //!
-//!   match unsatisfied_constraints {
-//!     Err(SigstoreError::SigstoreNoVerifiedLayer) => {
-//!       panic!("no signature is matching the requirements")
-//!     },
-//!     Err(e) => {
-//!       panic!("Something went wrong while verifying the image: {}", e)
-//!     },
-//!     Ok(unsatisfied_constraints) => {
-//!       if unsatisfied_constraints.len() > 0 {
-//!         println!("Not all requirements were satisfied:");
-//!         println!("{:?}", unsatisfied_constraints);
-//!       } else {
-//!         println!("Image verified.");
+//!   match result {
+//!       Ok(()) => {
+//!           println!("Image successfully verified");
 //!       }
-//!     }
+//!       Err(SigstoreVerifyConstraintsError {
+//!           unsatisfied_constraints,
+//!       }) => {
+//!           if unsatisfied_constraints.is_empty() {
+//!               println!("Image successfully verified");
+//!           } else {
+//!               println!("{:?}", unsatisfied_constraints);
+//!              panic!("Image verification failed")
+//!           }
+//!       }
 //!   }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! ```rust,no_run
 //! use crate::sigstore::cosign::{
 //!     CosignCapabilities,
-//!     filter_signature_layers,
+//!     filter_constraints,
 //! };
 //! use crate::sigstore::cosign::verification_constraint::{
 //!     AnnotationVerifier,
@@ -124,25 +124,29 @@
 //!     Box::new(pub_key_verifier),
 //!   ];
 //!
-//!   // Filter all the trusted layers, find the ones satisfying the constraints
-//!   // we just defined
-//!   let signatures_matching_requirements = filter_signature_layers(
+//!   // Filter the constraints, find the ones not satisfied by the layers on
+//!   // the image
+//!   let unsatisfied_constraints = filter_constraints(
 //!     &signature_layers,
 //!     verification_constraints);
 //!
-//!   match signatures_matching_requirements {
+//!   match unsatisfied_constraints {
 //!     Err(SigstoreError::SigstoreNoVerifiedLayer) => {
 //!       panic!("no signature is matching the requirements")
 //!     },
 //!     Err(e) => {
 //!       panic!("Something went wrong while verifying the image: {}", e)
 //!     },
-//!     Ok(signatures) => {
-//!       println!("signatures matching the requirements:");
-//!       serde_json::to_writer_pretty(
-//!           std::io::stdout(),
-//!           &signatures,
-//!       ).unwrap();
+//!     Ok(unsatisfied_constraints) => {
+//!       if unsatisfied_constraints.len() > 0 {
+//!         println!("Not all requirements were satisfied:");
+//!         // serde_json::to_writer_pretty(
+//!         //     std::io::stdout(),
+//!         //     &unsatisfied_constraints,
+//!         // ).unwrap();
+//!       } else {
+//!         println!("Image verified.");
+//!       }
 //!     }
 //!   }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,7 @@
 //!     Ok(unsatisfied_constraints) => {
 //!       if unsatisfied_constraints.len() > 0 {
 //!         println!("Not all requirements were satisfied:");
-//!         // serde_json::to_writer_pretty(
-//!         //     std::io::stdout(),
-//!         //     &unsatisfied_constraints,
-//!         // ).unwrap();
+//!         println!("{:?}", unsatisfied_constraints);
 //!       } else {
 //!         println!("Image verified.");
 //!       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,8 +125,9 @@
 //!     Box::new(pub_key_verifier),
 //!   ];
 //!
-//!   // Filter the constraints, find the ones not satisfied by the layers on
-//!   // the image
+//!   // Use the given list of constraints to verify the trusted
+//!   // `signature_layers`. This will raise an error if one or more verification
+//!   // constraints are not satisfied.
 //!   let result = verify_constraints(
 //!     &signature_layers,
 //!     verification_constraints.iter());
@@ -138,12 +139,8 @@
 //!       Err(SigstoreVerifyConstraintsError {
 //!           unsatisfied_constraints,
 //!       }) => {
-//!           if unsatisfied_constraints.is_empty() {
-//!               println!("Image successfully verified");
-//!           } else {
-//!               println!("{:?}", unsatisfied_constraints);
-//!              panic!("Image verification failed")
-//!           }
+//!           println!("{:?}", unsatisfied_constraints);
+//!           panic!("Image verification failed")
 //!       }
 //!   }
 //! }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->


#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

BREAKING CHANGE: Drop `cosign::filter_signature_layers` in favour of
`cosign::verify_constraints()`, that returns a new `SigstoreVerifyConstraintsError`
which contains references to unsatisfied constraints.

The relationship between layers and constraints is not injective (e.g:
AnnotationsVerifier), hence no image verification info could be derived
from the number of layers verified.

With unsatisfied constraints, we know that 0 means the image is
verified.
If we have some unsatisfied constraints, we can use them to provide info
on why we failed verification.

Add a test and consume changes.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/sigstore-rs/issues/41.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
fix!: Drop filter_signature_layers() for verify_constraints()
```
