### PR TITLE
fix handling of fulcio certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,15 @@ rustls-tls = ["oci-distribution/rustls-tls"]
 [dependencies]
 async-trait = "0.1.52"
 base64 = "0.13.0"
+lazy_static = "1.4.0"
 # TODO: go back to the officially release oci-distribution once these patches are released
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "0f717968093a5415f428503d741dedf24ea97948", default-features = false }
 #oci-distribution = { version = "0.8.1", default-features = false }
 olpc-cjson = "0.1.1"
 pem = "1.0.2"
+# TODO: get rid of the git reference on the crate is published on crates.io
+picky = { git = "https://github.com/Devolutions/picky-rs.git", tag = "picky-7.0.0-rc.1", default-features = false, features = [ "x509" ] }
+regex = "1.5.4"
 ring = "0.16.20"
 serde_json = "1.0.79"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -37,5 +41,6 @@ anyhow = "1.0.54"
 chrono = "0.4.19"
 clap = { version = "3.1.0", features = ["derive"] }
 openssl = "0.10.38"
+rstest = "0.12.0"
 tempfile = "3.3.0"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/examples/verify/main.rs
+++ b/examples/verify/main.rs
@@ -145,7 +145,7 @@ async fn run_app() -> anyhow::Result<(Vec<SignatureLayer>, VerificationConstrain
 
     if let Some(repo) = sigstore_repo {
         client_builder = client_builder.with_rekor_pub_key(repo.rekor_pub_key());
-        client_builder = client_builder.with_fulcio_cert(repo.fulcio_cert());
+        client_builder = client_builder.with_fulcio_certs(repo.fulcio_certs());
     }
 
     // Set Rekor public key. Give higher precendece to the key specified by the user over the

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -1,0 +1,86 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    errors::{Result, SigstoreError},
+    registry::Certificate,
+};
+
+/// A collection of trusted root certificates
+#[derive(Default, Debug)]
+pub(crate) struct CertificatePool {
+    trusted_roots: Vec<picky::x509::Cert>,
+}
+
+impl CertificatePool {
+    /// Build a `CertificatePool` instance using the provided list of [`Certificate`]
+    pub(crate) fn from_certificates(certs: &[Certificate]) -> Result<Self> {
+        let mut trusted_roots = vec![];
+
+        for c in certs {
+            let pc = match c.encoding {
+                crate::registry::CertificateEncoding::Pem => {
+                    let pem_str = String::from_utf8(c.data.clone()).map_err(|_| {
+                        SigstoreError::UnexpectedError("certificate is not PEM encoded".to_string())
+                    })?;
+                    picky::x509::Cert::from_pem_str(&pem_str)
+                }
+                crate::registry::CertificateEncoding::Der => picky::x509::Cert::from_der(&c.data),
+            }?;
+
+            if !matches!(pc.ty(), picky::x509::certificate::CertType::Root) {
+                return Err(SigstoreError::CertificatePoolError(
+                    "Cannot add non-root certificate".to_string(),
+                ));
+            }
+
+            trusted_roots.push(pc);
+        }
+
+        Ok(CertificatePool { trusted_roots })
+    }
+
+    /// Ensures the given certificate has been issued by one of the trusted root certificates
+    /// An `Err` is returned when the verification fails.
+    ///
+    /// **Note well:** certificates issued by Fulciuo are, by design, valid only
+    /// for a really limited amount of time.
+    /// Because of that the validity checks performed by this method are more
+    /// relaxed. The validity checks are done inside of
+    /// [`crate::crypto::verify_validity`] and [`crate::crypto::verify_expiration`].
+    pub(crate) fn verify(&self, cert_pem: &[u8]) -> Result<()> {
+        let cert_pem_str = String::from_utf8(cert_pem.to_vec()).map_err(|_| {
+            SigstoreError::UnexpectedError("Cannot convert cert back to string".to_string())
+        })?;
+        let cert = picky::x509::Cert::from_pem_str(&cert_pem_str)?;
+
+        let verified = self.trusted_roots.iter().any(|trusted_root| {
+            let chain = [trusted_root.clone()];
+            cert.verifier()
+                .chain(chain.iter())
+                .exact_date(&cert.valid_not_before())
+                .verify()
+                .is_ok()
+        });
+
+        if verified {
+            Ok(())
+        } else {
+            Err(SigstoreError::CertificateValidityError(
+                "Not issued by a trusted root".to_string(),
+            ))
+        }
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -64,6 +64,7 @@ pub enum Signature<'a> {
 }
 
 pub(crate) mod certificate;
+pub(crate) mod certificate_pool;
 
 pub mod verification_key;
 pub use verification_key::CosignVerificationKey;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,8 +112,8 @@ pub enum SigstoreError {
     #[error("Rekor bundle missing")]
     SigstoreRekorBundleNotFoundError,
 
-    #[error("Fulcio public key not provided")]
-    SigstoreFulcioPublicNotProvidedError,
+    #[error("Fulcio certificates not provided")]
+    SigstoreFulcioCertificatesNotProvidedError,
 
     #[error("No Signature Layer passed verification")]
     SigstoreNoVerifiedLayer,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,9 +40,11 @@ pub enum SigstoreError {
 
     #[error(transparent)]
     X509ParseError(#[from] x509_parser::nom::Err<x509_parser::error::X509Error>),
-
     #[error(transparent)]
     X509Error(#[from] x509_parser::error::X509Error),
+
+    #[error(transparent)]
+    CertError(#[from] picky::x509::certificate::CertError),
 
     #[error(transparent)]
     Base64DecodeError(#[from] base64::DecodeError),
@@ -82,6 +84,9 @@ pub enum SigstoreError {
 
     #[error("Certificate with incomplete Subject Alternative Name")]
     CertificateWithIncompleteSubjectAlternativeName,
+
+    #[error("Certificate pool error: {0}")]
+    CertificatePoolError(String),
 
     #[error("Cannot fetch manifest of {image}: {error}")]
     RegistryFetchManifestError { image: String, error: String },

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -18,6 +18,7 @@
 use crate::errors::{Result, SigstoreError};
 
 use async_trait::async_trait;
+use std::cmp::Ordering;
 use std::convert::From;
 
 /// A method for authenticating to a registry
@@ -69,7 +70,7 @@ impl From<ClientProtocol> for oci_distribution::client::ClientProtocol {
 }
 
 /// The encoding of the certificate
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CertificateEncoding {
     #[allow(missing_docs)]
     Der,
@@ -87,13 +88,25 @@ impl From<CertificateEncoding> for oci_distribution::client::CertificateEncoding
 }
 
 /// A x509 certificate
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Certificate {
     /// Which encoding is used by the certificate
     pub encoding: CertificateEncoding,
 
     /// Actual certificate
     pub data: Vec<u8>,
+}
+
+impl Ord for Certificate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.data.cmp(&other.data)
+    }
+}
+
+impl PartialOrd for Certificate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl From<&Certificate> for oci_distribution::client::Certificate {

--- a/src/tuf/constants.rs
+++ b/src/tuf/constants.rs
@@ -13,11 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    pub(crate) static ref SIGSTORE_FULCIO_CERT_TARGET_REGEX: Regex =
+        Regex::new(r#"fulcio(_v\d+)?\.crt\.pem"#).unwrap();
+}
+
 pub(crate) const SIGSTORE_METADATA_BASE: &str = "http://sigstore-tuf-root.storage.googleapis.com/";
 pub(crate) const SIGSTORE_TARGET_BASE: &str =
     "http://sigstore-tuf-root.storage.googleapis.com/targets";
 
-pub(crate) const SIGSTORE_FULCIO_CERT_TARGET: &str = "fulcio.crt.pem";
 pub(crate) const SIGSTORE_REKOR_PUB_KEY_TARGET: &str = "rekor.pub";
 
 pub(crate) const SIGSTORE_ROOT: &str = r#"{
@@ -164,3 +171,18 @@ pub(crate) const SIGSTORE_ROOT: &str = r#"{
 		"version": 2
 	}
 }"#;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    #[case("fulcio.crt.pem", true)]
+    #[case("fulcio_v1.crt.pem", true)]
+    #[case("fulcio-v2.crt.pem", false)]
+    #[case("foo.crt.pem", false)]
+    fn check_fulcio_regex(#[case] input: &str, #[case] matches: bool) {
+        assert_eq!(SIGSTORE_FULCIO_CERT_TARGET_REGEX.is_match(input), matches);
+    }
+}

--- a/src/tuf/mod.rs
+++ b/src/tuf/mod.rs
@@ -34,7 +34,7 @@
 //!     .expect("Error while building SigstoreRepository");
 //! let client = cosign::ClientBuilder::default()
 //!     .with_rekor_pub_key(repo.rekor_pub_key())
-//!     .with_fulcio_cert(repo.fulcio_cert())
+//!     .with_fulcio_certs(repo.fulcio_certs())
 //!     .build()
 //!     .expect("Error while building cosign client");
 //! ```
@@ -57,10 +57,10 @@ use repository_helper::RepositoryHelper;
 
 use super::errors::{Result, SigstoreError};
 
-/// Securely fetches Rekor public key and Fulcio certificate from Sigstore's TUF repository
+/// Securely fetches Rekor public key and Fulcio certificates from Sigstore's TUF repository
 pub struct SigstoreRepository {
     rekor_pub_key: String,
-    fulcio_cert: Vec<u8>,
+    fulcio_certs: Vec<crate::registry::Certificate>,
 }
 
 impl SigstoreRepository {
@@ -69,7 +69,7 @@ impl SigstoreRepository {
     /// ## Parameters
     ///
     /// * `checkout_dir`: path to a local directory where Rekor's public
-    /// key and Fulcio's certificate can be found
+    /// key and Fulcio's certificates can be found
     ///
     /// ## Behaviour
     ///
@@ -135,7 +135,7 @@ impl SigstoreRepository {
             checkout_dir,
         )?;
 
-        let fulcio_cert = repository_helper.fulcio_cert()?;
+        let fulcio_certs = repository_helper.fulcio_certs()?;
 
         let rekor_pub_key = repository_helper.rekor_pub_key().map(|data| {
             String::from_utf8(data).map_err(|e| {
@@ -148,7 +148,7 @@ impl SigstoreRepository {
 
         Ok(SigstoreRepository {
             rekor_pub_key,
-            fulcio_cert,
+            fulcio_certs,
         })
     }
 
@@ -158,7 +158,7 @@ impl SigstoreRepository {
     }
 
     /// Fulcio certificate
-    pub fn fulcio_cert(&self) -> &[u8] {
-        &self.fulcio_cert
+    pub fn fulcio_certs(&self) -> &[crate::registry::Certificate] {
+        &self.fulcio_certs
     }
 }


### PR DESCRIPTION
#### Summary

Fulcio has recently introduced a new root CA to issue certificates. Prior to this commit, the code was making use only of the initial root CA.
Because of that, recent keyless signatures were considered not valid.

Now the code is taking into account of the root CAs that Fulcio used over the time.

#### Ticket Link

Fixes https://github.com/sigstore/sigstore-rs/issues/32

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Fix(TUF): fetch all the Fulcio certificates found inside of the TUF repository
* Fix(Verification): ensure all the Fulcio root certificates are used to verify signatures. This fixes issue #32
```
