### PR TITLE
Ensure docs are automatically published

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  deployments: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `docs` GitHub Action job has been failing lately. We have changed the default settings of the `GITHUB` token to have read-only capabilities.

This breaks the `docs` action, because the action performs the following operation:

  * Checkout the code
  * Render the docs
  * Push the new docs to a dedicated branch of the repository

The last step is broken by the lack of write permissions associated with the GITHUB token.

This commits adds the permissions that are required to perform commits.

Hopefully this is going to be enough, if not I'll create a new PR which instead uses a deployment key.
