### PR TITLE
Fix docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  deployments: write
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -26,5 +23,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.DOCS_GH_DEPLOYMENT_PRIVATE_KEY }}
           publish_dir: ./target/doc/


### PR DESCRIPTION
Using permissions wasn't enough to allow the GitHub Action to publish the docs.

This commit switches away from the GITHUB_TOKEN, and uses a dedicated deployment key.

For more details, see https://github.com/sigstore/sigstore-rs/pull/44
