### PR TITLE
Update picky dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev =
 #oci-distribution = { version = "0.8.1", default-features = false }
 olpc-cjson = "0.1.1"
 pem = "1.0.2"
-# TODO: get rid of the git reference on the crate is published on crates.io
-picky = { git = "https://github.com/Devolutions/picky-rs.git", tag = "picky-7.0.0-rc.2", default-features = false, features = [ "x509" ] }
+picky = { version = "7.0.0-rc.2", default-features = false, features = [ "x509" ] }
 regex = "1.5.5"
 ring = "0.16.20"
 serde_json = "1.0.79"


### PR DESCRIPTION
Consume it from crates.io, the RC builds are already available over there.
