### PR TITLE
OCI caching client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustls-tls = ["oci-distribution/rustls-tls", "openidconnect/rustls-tls"]
 [dependencies]
 async-trait = "0.1.52"
 base64 = "0.13.0"
+cached = "0.34.0"
 lazy_static = "1.4.0"
 # TODO: go back to the officially release oci-distribution once these patches are released
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "0f717968093a5415f428503d741dedf24ea97948", default-features = false }

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -15,10 +15,12 @@
 
 //! Set of structs and enums used to define how to interact with OCI registries
 
+use serde::Serialize;
 use std::cmp::Ordering;
 use std::convert::From;
 
 /// A method for authenticating to a registry
+#[derive(Serialize, Debug)]
 pub enum Auth {
     /// Access the registry anonymously
     Anonymous,
@@ -32,6 +34,17 @@ impl From<&Auth> for oci_distribution::secrets::RegistryAuth {
             Auth::Anonymous => oci_distribution::secrets::RegistryAuth::Anonymous,
             Auth::Basic(username, pass) => {
                 oci_distribution::secrets::RegistryAuth::Basic(username.clone(), pass.clone())
+            }
+        }
+    }
+}
+
+impl From<&oci_distribution::secrets::RegistryAuth> for Auth {
+    fn from(auth: &oci_distribution::secrets::RegistryAuth) -> Self {
+        match auth {
+            oci_distribution::secrets::RegistryAuth::Anonymous => Auth::Anonymous,
+            oci_distribution::secrets::RegistryAuth::Basic(username, pass) => {
+                Auth::Basic(username.clone(), pass.clone())
             }
         }
     }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,0 +1,47 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod config;
+pub use config::*;
+
+pub(crate) mod oci_client;
+pub(crate) use oci_client::*;
+
+use crate::errors::Result;
+
+use async_trait::async_trait;
+
+#[async_trait]
+/// Capabilities that are expected to be provided by a registry client
+pub(crate) trait ClientCapabilities: Send + Sync {
+    async fn fetch_manifest_digest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<String>;
+
+    async fn pull(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+        accepted_media_types: Vec<&str>,
+    ) -> Result<oci_distribution::client::ImageData>;
+
+    async fn pull_manifest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<(oci_distribution::manifest::OciManifest, String)>;
+}

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -19,6 +19,9 @@ pub use config::*;
 pub(crate) mod oci_client;
 pub(crate) use oci_client::*;
 
+pub(crate) mod oci_caching_client;
+pub(crate) use oci_caching_client::*;
+
 use crate::errors::Result;
 
 use async_trait::async_trait;

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -1,0 +1,298 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::ClientCapabilities;
+use crate::errors::{Result, SigstoreError};
+
+use async_trait::async_trait;
+use cached::proc_macro::cached;
+use olpc_cjson::CanonicalFormatter;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tracing::{debug, error};
+
+/// Internal client for an OCI Registry. This performs actual
+/// calls against the remote registry and caches the results
+/// for 60 seconds.
+///
+/// For testing purposes, use instead the client inside of the
+/// `mock_client` module.
+pub(crate) struct OciCachingClient {
+    pub registry_client: oci_distribution::Client,
+}
+
+#[cached(
+    time = 60,
+    result = true,
+    sync_writes = true,
+    key = "String",
+    convert = r#"{ format!("{}", image) }"#,
+    with_cached_flag = true
+)]
+async fn fetch_manifest_digest_cached(
+    client: &mut oci_distribution::Client,
+    image: &oci_distribution::Reference,
+    auth: &oci_distribution::secrets::RegistryAuth,
+) -> Result<cached::Return<String>> {
+    client
+        .fetch_manifest_digest(image, auth)
+        .await
+        .map_err(|e| SigstoreError::RegistryFetchManifestError {
+            image: image.whole(),
+            error: e.to_string(),
+        })
+        .map(cached::Return::new)
+}
+
+/// Internal struct, used to calculate a unique hash of the pull
+/// settings. This is required to cache pull results.
+#[derive(Serialize, Debug)]
+struct PullSettings<'a> {
+    image: String,
+    auth: super::config::Auth,
+    pub accepted_media_types: Vec<&'a str>,
+}
+
+impl<'a> PullSettings<'a> {
+    fn new(
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+        accepted_media_types: Vec<&'a str>,
+    ) -> PullSettings<'a> {
+        let image_str = image.whole();
+        let auth_sigstore: super::config::Auth = From::from(auth);
+
+        PullSettings {
+            image: image_str,
+            auth: auth_sigstore,
+            accepted_media_types,
+        }
+    }
+
+    pub fn image(&self) -> oci_distribution::Reference {
+        // we can use `unwrap` here, because this will never fail
+        let reference: oci_distribution::Reference = self.image.parse().unwrap();
+        reference
+    }
+
+    pub fn auth(&self) -> oci_distribution::secrets::RegistryAuth {
+        let internal_auth: &super::config::Auth = &self.auth;
+        let a: oci_distribution::secrets::RegistryAuth = internal_auth.into();
+        a
+    }
+
+    // This function returns a hash of the PullSettings struct.
+    // The has is computed by doing a canonical JSON representation of
+    // the struct.
+    //
+    // This method cannot error, because its value is used by the `cached`
+    // macro, which doesn't allow error handling.
+    // Because of that the method will return the '0' value when something goes
+    // wrong during the serialization operation. This is very unlikely to happen
+    pub fn hash(&self) -> String {
+        let mut buf = Vec::new();
+        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
+        if let Err(e) = self.serialize(&mut ser) {
+            error!(err=?e, settings=?self, "Cannot perform canonical serialization");
+            return "0".to_string();
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(&buf);
+        let result = hasher.finalize();
+        result
+            .iter()
+            .map(|v| format!("{:x}", v))
+            .collect::<Vec<String>>()
+            .join("")
+    }
+}
+
+// Pulls an OCI artifact.
+// Details about this cache:
+//   * the cache is time bound: cached values are purged after 60 seconds
+//   * only successful results are cached
+#[cached(
+    time = 60,
+    result = true,
+    sync_writes = true,
+    key = "String",
+    convert = r#"{ settings.hash() }"#,
+    with_cached_flag = true
+)]
+async fn pull_cached(
+    client: &mut oci_distribution::Client,
+    settings: PullSettings<'_>,
+) -> Result<cached::Return<oci_distribution::client::ImageData>> {
+    let auth = settings.auth();
+    let image = settings.image();
+
+    client
+        .pull(&image, &auth, settings.accepted_media_types)
+        .await
+        .map_err(|e| SigstoreError::RegistryPullError {
+            image: image.whole(),
+            error: e.to_string(),
+        })
+        .map(cached::Return::new)
+}
+
+/// Internal struct, used to calculate a unique hash of the pull manifest
+/// settings. This is required to cache pull manifest results.
+#[derive(Serialize, Debug)]
+struct PullManifestSettings {
+    image: String,
+    auth: super::config::Auth,
+}
+
+impl PullManifestSettings {
+    fn new(
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> PullManifestSettings {
+        let image_str = image.whole();
+        let auth_sigstore: super::config::Auth = From::from(auth);
+
+        PullManifestSettings {
+            image: image_str,
+            auth: auth_sigstore,
+        }
+    }
+
+    pub fn image(&self) -> oci_distribution::Reference {
+        // we can use `unwrap` here, because this will never fail
+        let reference: oci_distribution::Reference = self.image.parse().unwrap();
+        reference
+    }
+
+    pub fn auth(&self) -> oci_distribution::secrets::RegistryAuth {
+        let internal_auth: &super::config::Auth = &self.auth;
+        let a: oci_distribution::secrets::RegistryAuth = internal_auth.into();
+        a
+    }
+
+    // This function returns a hash of the PullManifestSettings struct.
+    // The has is computed by doing a canonical JSON representation of
+    // the struct.
+    //
+    // This method cannot error, because its value is used by the `cached`
+    // macro, which doesn't allow error handling.
+    // Because of that the method will return the '0' value when something goes
+    // wrong during the serialization operation. This is very unlikely to happen
+    pub fn hash(&self) -> String {
+        let mut buf = Vec::new();
+        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
+        if let Err(e) = self.serialize(&mut ser) {
+            error!(err=?e, settings=?self, "Cannot perform canonical serialization");
+            return "0".to_string();
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(&buf);
+        let result = hasher.finalize();
+        result
+            .iter()
+            .map(|v| format!("{:x}", v))
+            .collect::<Vec<String>>()
+            .join("")
+    }
+}
+
+// Pulls an OCI manifest.
+// Details about this cache:
+//   * the cache is time bound: cached values are purged after 60 seconds
+//   * only successful results are cached
+#[cached(
+    time = 60,
+    result = true,
+    sync_writes = true,
+    key = "String",
+    convert = r#"{ settings.hash() }"#,
+    with_cached_flag = true
+)]
+async fn pull_manifest_cached(
+    client: &mut oci_distribution::Client,
+    settings: PullManifestSettings,
+) -> Result<cached::Return<(oci_distribution::manifest::OciManifest, String)>> {
+    let image = settings.image();
+    let auth = settings.auth();
+    client
+        .pull_manifest(&image, &auth)
+        .await
+        .map_err(|e| SigstoreError::RegistryPullManifestError {
+            image: image.whole(),
+            error: e.to_string(),
+        })
+        .map(cached::Return::new)
+}
+
+#[async_trait]
+impl ClientCapabilities for OciCachingClient {
+    async fn fetch_manifest_digest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<String> {
+        fetch_manifest_digest_cached(&mut self.registry_client, image, auth)
+            .await
+            .map(|digest| {
+                if digest.was_cached {
+                    debug!(?image, "Got image digest from cache");
+                } else {
+                    debug!(?image, "Got image digest by querying remote registry");
+                }
+                digest.value
+            })
+    }
+
+    async fn pull(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+        accepted_media_types: Vec<&str>,
+    ) -> Result<oci_distribution::client::ImageData> {
+        let pull_settings = PullSettings::new(image, auth, accepted_media_types);
+
+        pull_cached(&mut self.registry_client, pull_settings)
+            .await
+            .map(|data| {
+                if data.was_cached {
+                    debug!(?image, "Got image data from cache");
+                } else {
+                    debug!(?image, "Got image data by querying remote registry");
+                }
+                data.value
+            })
+    }
+
+    async fn pull_manifest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<(oci_distribution::manifest::OciManifest, String)> {
+        let pull_manifest_settings = PullManifestSettings::new(image, auth);
+
+        pull_manifest_cached(&mut self.registry_client, pull_manifest_settings)
+            .await
+            .map(|data| {
+                if data.was_cached {
+                    debug!(?image, "Got image manifest from cache");
+                } else {
+                    debug!(?image, "Got image manifest by querying remote registry");
+                }
+                data.value
+            })
+    }
+}

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -1,0 +1,74 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::ClientCapabilities;
+use crate::errors::{Result, SigstoreError};
+
+use async_trait::async_trait;
+
+/// Internal client for an OCI Registry. This performs actual
+/// calls against the remote registry.OciClient
+///
+/// For testing purposes, use instead the client inside of the
+/// `mock_client` module.
+pub(crate) struct OciClient {
+    pub registry_client: oci_distribution::Client,
+}
+
+#[async_trait]
+impl ClientCapabilities for OciClient {
+    async fn fetch_manifest_digest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<String> {
+        self.registry_client
+            .fetch_manifest_digest(image, auth)
+            .await
+            .map_err(|e| SigstoreError::RegistryFetchManifestError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
+    }
+
+    async fn pull(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+        accepted_media_types: Vec<&str>,
+    ) -> Result<oci_distribution::client::ImageData> {
+        self.registry_client
+            .pull(image, auth, accepted_media_types)
+            .await
+            .map_err(|e| SigstoreError::RegistryPullError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
+    }
+
+    async fn pull_manifest(
+        &mut self,
+        image: &oci_distribution::Reference,
+        auth: &oci_distribution::secrets::RegistryAuth,
+    ) -> Result<(oci_distribution::manifest::OciManifest, String)> {
+        self.registry_client
+            .pull_manifest(image, auth)
+            .await
+            .map_err(|e| SigstoreError::RegistryPullManifestError {
+                image: image.whole(),
+                error: e.to_string(),
+            })
+    }
+}


### PR DESCRIPTION
Allow end consumers of the library to create a `cosign::Client` that caches the response it gets from OCI registries.

The cache entries are automatically expired after 60 seconds.

This can be useful in certain scenarios, like when writing code that can verify the same container image, but with different constraints.

Imagine the following scenario: write a REST API that exposes sigstore verification capabilities.
In this case, the REST API can receive multiple verification requests of the same image, but each time with slightly different verification constraints.
Thanks to the registry caching feature, the REST server would significantly reduce the number of interactions with the remote OCI registry. That would lead to shorter response times and higher request per seconds.

To be completely honest, this is something we need inside of kubewarden, but I think others could benefit from that. If this is not something relevant for this library we could just move this code into kubewarden :peace_symbol: 

## Demo

Running without caching:

```console
╰─ cargo run --example verify -- --use-sigstore-tuf-data --loops 3 ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.3
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/examples/verify --use-sigstore-tuf-data --loops 3 'ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.3'`
2022-04-08T12:30:14.688800Z  INFO verify: Downloading data from Sigstore TUF repository
Loop 1/3
Image successfully verified
Elapsed: 1.84s
------
Loop 2/3
Image successfully verified
Elapsed: 1.38s
------
Loop 3/3
Image successfully verified
Elapsed: 1.58s
------
```

Using caching:

```console
╰─ cargo run --example verify -- --use-sigstore-tuf-data --loops 3 --enable-registry-caching ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.3
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/examples/verify --use-sigstore-tuf-data --loops 3 --enable-registry-caching 'ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.3'`
2022-04-08T12:30:59.931631Z  INFO verify: Downloading data from Sigstore TUF repository
Loop 1/3
Image successfully verified
Elapsed: 1.55s
------
Loop 2/3
Image successfully verified
Elapsed: 21.72ms
------
Loop 3/3
Image successfully verified
Elapsed: 16.23ms
------
```