### PR TITLE
No need to unwrap as we return within a Result

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -144,4 +144,7 @@ pub enum SigstoreError {
 
     #[error("Verification of OIDC claims received from OpenIdProvider failed")]
     ClaimsVerificationError,
+
+    #[error("Failed to access token endpoint")]
+    ClaimsAccessPointError,
 }

--- a/src/oauth/openidflow.rs
+++ b/src/oauth/openidflow.rs
@@ -245,10 +245,7 @@ impl RedirectListener {
                     .exchange_code(code)
                     .set_pkce_verifier(self.pkce_verifier)
                     .request(http_client)
-                    .unwrap_or_else(|_err| {
-                        error!("Failed to access token endpoint");
-                        unreachable!();
-                    });
+                    .map_err(|_| SigstoreError::ClaimsAccessPointError)?;
 
                 let id_token_verifier: CoreIdTokenVerifier = self.client.id_token_verifier();
                 let id_token_claims: &CoreIdTokenClaims = token_response


### PR DESCRIPTION
Remove unwrap or else and instead map_err and bubble up with the ?
operator.

Signed-off-by: Luke Hinds <lhinds@redhat.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
