### PR TITLE
Update to latest version of x509-parser crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,7 @@ tokio = { version = "1.17.0", features = ["full"] }
 tough = { version = "0.12.1", features = [ "http" ] }
 tracing = "0.1.31"
 url = "2.2.2"
-# DO not update to 0.13.0 - wait for a release that includes https://github.com/rusticata/x509-parser/pull/118 to be published
-x509-parser = { version = "0.12.0", features = ["verify"] }
+x509-parser = { version = "0.13.2", features = ["verify"] }
 
 
 [dev-dependencies]

--- a/src/crypto/certificate.rs
+++ b/src/crypto/certificate.rs
@@ -33,19 +33,19 @@ pub(crate) fn is_trusted(certificate: &X509Certificate, integrated_time: i64) ->
 }
 
 fn verify_key_usages(certificate: &X509Certificate) -> Result<()> {
-    let (_critical, key_usage) = certificate
+    let key_usage = certificate
         .tbs_certificate
-        .key_usage()
+        .key_usage()?
         .ok_or(SigstoreError::CertificateWithoutDigitalSignatureKeyUsage)?;
-    if !key_usage.digital_signature() {
+    if !key_usage.value.digital_signature() {
         return Err(SigstoreError::CertificateWithoutDigitalSignatureKeyUsage);
     }
 
-    let (_critical, ext_key_usage) = certificate
+    let ext_key_usage = certificate
         .tbs_certificate
-        .extended_key_usage()
+        .extended_key_usage()?
         .ok_or(SigstoreError::CertificateWithoutCodeSigningKeyUsage)?;
-    if !ext_key_usage.code_signing {
+    if !ext_key_usage.value.code_signing {
         return Err(SigstoreError::CertificateWithoutCodeSigningKeyUsage);
     }
 
@@ -53,9 +53,9 @@ fn verify_key_usages(certificate: &X509Certificate) -> Result<()> {
 }
 
 fn verify_has_san(certificate: &X509Certificate) -> Result<()> {
-    let (_critical, _subject_alternative_name) = certificate
+    let _subject_alternative_name = certificate
         .tbs_certificate
-        .subject_alternative_name()
+        .subject_alternative_name()?
         .ok_or(SigstoreError::CertificateWithoutSubjectAlternativeName)?;
     Ok(())
 }


### PR DESCRIPTION
Address the compilation issues introduced by the API changes.

This supersedes https://github.com/sigstore/sigstore-rs/pull/57

