### PR TITLE
Implements CI check for unsafe, unwrap and panic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
           command: test
           args: --workspace
 
-  fmt:
-    name: Rustfmt
+  static:
+    name: Static code checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -47,6 +47,8 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+    - name: Check for panics / unwraps
+      - run: ./tests/ban-list.py
 
   clippy:
     name: Clippy
@@ -63,3 +65,4 @@ jobs:
         with:
           command: clippy
           args: --workspace -- -D warnings
+

--- a/src/cosign/bundle.rs
+++ b/src/cosign/bundle.rs
@@ -82,7 +82,7 @@ mod tests {
             "logID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
           }
         });
-        serde_json::to_string(&bundle_json).unwrap()
+        serde_json::to_string(&bundle_json).unwrap() //#[allow_ci]
     }
 
     #[test]

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -154,7 +154,7 @@ mod tests {
         let image = "docker.io/busybox:latest";
         let image_digest =
             String::from("sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b");
-        let expected_image = "docker.io/library/busybox:sha256-f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b.sig".parse().unwrap();
+        let expected_image = "docker.io/library/busybox:sha256-f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b.sig".parse().unwrap(); //#[allow_ci]
         let mock_client = MockOciClient {
             fetch_manifest_digest_response: Some(Ok(image_digest.clone())),
             pull_response: None,
@@ -167,6 +167,6 @@ mod tests {
             .await;
 
         assert!(reference.is_ok());
-        assert_eq!(reference.unwrap(), (expected_image, image_digest));
+        assert_eq!(reference.unwrap(), (expected_image, image_digest)); //#[allow_ci]
     }
 }

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -197,7 +197,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
                 data: FULCIO_CRT_2_PEM.as_bytes().to_vec(),
             },
         ];
-        CertificatePool::from_certificates(&certificates).unwrap()
+        CertificatePool::from_certificates(&certificates).unwrap() //#[allow_ci]
     }
 
     pub(crate) fn get_rekor_public_key() -> CosignVerificationKey {
@@ -220,7 +220,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
         let mut layers: Vec<SignatureLayer> = Vec::new();
         for _ in 0..5 {
             let mut sl = build_correct_signature_layer_with_certificate();
-            let mut cert_signature = sl.certificate_signature.unwrap();
+            let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
             let cert_subj = CertificateSubject::Email(email.clone());
             cert_signature.issuer = Some(issuer.clone());
             cert_signature.subject = cert_subj;
@@ -272,7 +272,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
         let mut layers: Vec<SignatureLayer> = Vec::new();
         for _ in 0..5 {
             let mut sl = build_correct_signature_layer_with_certificate();
-            let mut cert_signature = sl.certificate_signature.unwrap();
+            let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
             let cert_subj = CertificateSubject::Email(email.clone());
             cert_signature.issuer = Some(issuer.clone());
             cert_signature.subject = cert_subj;
@@ -320,7 +320,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
         let mut layers: Vec<SignatureLayer> = Vec::new();
         for _ in 0..5 {
             let mut sl = build_correct_signature_layer_with_certificate();
-            let mut cert_signature = sl.certificate_signature.unwrap();
+            let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
             let cert_subj = CertificateSubject::Email(email.clone());
             cert_signature.issuer = Some(issuer.clone());
             cert_signature.subject = cert_subj;

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -424,12 +424,12 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
 
         (
             SignatureLayer {
-                simple_signing: serde_json::from_value(ss_value.clone()).unwrap(),
+                simple_signing: serde_json::from_value(ss_value.clone()).unwrap(), //#[allow_ci]
                 oci_digest: String::from("digest"),
                 signature,
                 bundle: None,
                 certificate_signature: None,
-                raw_data: serde_json::to_vec(&ss_value).unwrap(),
+                raw_data: serde_json::to_vec(&ss_value).unwrap(), //#[allow_ci]
             },
             verification_key,
         )
@@ -488,12 +488,12 @@ oXqqo/C9QnOHTto=
                 .expect("Cannot create certificate signature");
 
         SignatureLayer {
-            simple_signing: serde_json::from_value(ss_value.clone()).unwrap(),
+            simple_signing: serde_json::from_value(ss_value.clone()).unwrap(), //#[allow_ci]
             oci_digest: String::from("sha256:5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e"),
             signature: String::from("MEUCIGqWScz7s9aP2sGXNFKeqivw3B6kPRs56AITIHnvd5igAiEA1kzbaV2Y5yPE81EN92NUFOl31LLJSvwsjFQ07m2XqaA="),
             bundle: Some(bundle),
             certificate_signature: Some(certificate_signature),
-            raw_data: serde_json::to_vec(&ss_value).unwrap(),
+            raw_data: serde_json::to_vec(&ss_value).unwrap(), //#[allow_ci]
         }
     }
 
@@ -639,7 +639,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
         let actual =
             SignatureLayer::get_bundle_from_annotations(&annotations, Some(&rekor_pub_key));
         assert!(actual.is_ok());
-        assert!(actual.unwrap().is_none());
+        assert!(actual.unwrap().is_none()); //#[allow_ci]
     }
 
     #[test]
@@ -653,7 +653,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
             None,
         );
 
-        assert!(actual.unwrap().is_none());
+        assert!(actual.unwrap().is_none()); //#[allow_ci]
     }
 
     #[test]
@@ -752,10 +752,10 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
         let issued_cert_pem = issued_cert.cert.to_pem()?;
 
-        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()];
-        let cert_pool = CertificatePool::from_certificates(&certs).unwrap();
+        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()]; //#[allow_ci]
+        let cert_pool = CertificatePool::from_certificates(&certs).unwrap(); //#[allow_ci]
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap(); //#[allow_ci]
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {
@@ -799,10 +799,10 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
         let issued_cert_pem = issued_cert.cert.to_pem()?;
 
-        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()];
-        let cert_pool = CertificatePool::from_certificates(&certs).unwrap();
+        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()]; //#[allow_ci]
+        let cert_pool = CertificatePool::from_certificates(&certs).unwrap(); //#[allow_ci]
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap(); //#[allow_ci]
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {
@@ -845,10 +845,10 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
         let issued_cert_pem = issued_cert.cert.to_pem()?;
 
-        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()];
-        let cert_pool = CertificatePool::from_certificates(&certs).unwrap();
+        let certs = vec![crate::registry::Certificate::try_from(ca_data.cert).unwrap()]; //#[allow_ci]
+        let cert_pool = CertificatePool::from_certificates(&certs).unwrap(); //#[allow_ci]
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap(); //#[allow_ci]
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {

--- a/src/cosign/verification_constraint.rs
+++ b/src/cosign/verification_constraint.rs
@@ -314,17 +314,17 @@ mod tests {
         let (sl, key) = build_correct_signature_layer_without_bundle();
 
         let vc = PublicKeyVerifier { key };
-        assert!(vc.verify(&sl).unwrap());
+        assert!(vc.verify(&sl).unwrap()); //#[allow_ci]
 
         let sl = build_correct_signature_layer_with_certificate();
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 
     #[test]
     fn cert_email_verifier_only_email() {
         let email = "alice@example.com".to_string();
         let mut sl = build_correct_signature_layer_with_certificate();
-        let mut cert_signature = sl.certificate_signature.unwrap();
+        let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
         let cert_subj = CertificateSubject::Email(email.clone());
         cert_signature.issuer = None;
         cert_signature.subject = cert_subj;
@@ -334,20 +334,20 @@ mod tests {
             email,
             issuer: None,
         };
-        assert!(vc.verify(&sl).unwrap());
+        assert!(vc.verify(&sl).unwrap()); //#[allow_ci]
 
         let vc = CertSubjectEmailVerifier {
             email: "different@email.com".to_string(),
             issuer: None,
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 
     #[test]
     fn cert_email_verifier_email_and_issuer() {
         let email = "alice@example.com".to_string();
         let mut sl = build_correct_signature_layer_with_certificate();
-        let mut cert_signature = sl.certificate_signature.unwrap();
+        let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
 
         // The cerificate subject doesn't have an issuer
         let cert_subj = CertificateSubject::Email(email.clone());
@@ -360,7 +360,7 @@ mod tests {
             email: email.clone(),
             issuer: Some("an issuer".to_string()),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
 
         // The cerificate subject has an issuer
         let issuer = "the issuer".to_string();
@@ -373,20 +373,20 @@ mod tests {
             email: email.clone(),
             issuer: Some(issuer.clone()),
         };
-        assert!(vc.verify(&sl).unwrap());
+        assert!(vc.verify(&sl).unwrap()); //#[allow_ci]
 
         let vc = CertSubjectEmailVerifier {
             email,
             issuer: Some("another issuer".to_string()),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
 
         // another verifier should fail
         let vc = CertSubjectUrlVerifier {
             url: "https://sigstore.dev/test".to_string(),
             issuer,
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 
     #[test]
@@ -397,7 +397,7 @@ mod tests {
             email: "alice@example.com".to_string(),
             issuer: None,
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 
     #[test]
@@ -406,7 +406,7 @@ mod tests {
         let issuer = "the issuer".to_string();
 
         let mut sl = build_correct_signature_layer_with_certificate();
-        let mut cert_signature = sl.certificate_signature.unwrap();
+        let mut cert_signature = sl.certificate_signature.unwrap(); //#[allow_ci]
         let cert_subj = CertificateSubject::Uri(url.clone());
         cert_signature.issuer = Some(issuer.clone());
         cert_signature.subject = cert_subj;
@@ -416,26 +416,26 @@ mod tests {
             url: url.clone(),
             issuer: issuer.clone(),
         };
-        assert!(vc.verify(&sl).unwrap());
+        assert!(vc.verify(&sl).unwrap()); //#[allow_ci]
 
         let vc = CertSubjectUrlVerifier {
             url: "a different url".to_string(),
             issuer: issuer.clone(),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
 
         let vc = CertSubjectUrlVerifier {
             url,
             issuer: "a different issuer".to_string(),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
 
         // A Cert email verifier should also report a non match
         let vc = CertSubjectEmailVerifier {
             email: "alice@example.com".to_string(),
             issuer: Some(issuer),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 
     #[test]
@@ -446,6 +446,6 @@ mod tests {
             url: "https://sigstore.dev/test".to_string(),
             issuer: "an issuer".to_string(),
         };
-        assert!(!vc.verify(&sl).unwrap());
+        assert!(!vc.verify(&sl).unwrap()); //#[allow_ci]
     }
 }

--- a/src/crypto/certificate.rs
+++ b/src/crypto/certificate.rs
@@ -219,8 +219,8 @@ mod tests {
         let issued_cert = generate_certificate(
             Some(&ca_data),
             CertGenerationOptions {
-                not_before: Utc::now().checked_add_signed(Duration::days(5)).unwrap(),
-                not_after: Utc::now().checked_add_signed(Duration::days(6)).unwrap(),
+                not_before: Utc::now().checked_add_signed(Duration::days(5)).unwrap(), //#[allow_ci]
+                not_after: Utc::now().checked_add_signed(Duration::days(6)).unwrap(), //#[allow_ci]
                 ..Default::default()
             },
         )?;
@@ -247,8 +247,8 @@ mod tests {
         let issued_cert = generate_certificate(
             Some(&ca_data),
             CertGenerationOptions {
-                not_before: Utc::now().checked_sub_signed(Duration::days(1)).unwrap(),
-                not_after: Utc::now().checked_add_signed(Duration::days(1)).unwrap(),
+                not_before: Utc::now().checked_sub_signed(Duration::days(1)).unwrap(), //#[allow_ci]
+                not_after: Utc::now().checked_add_signed(Duration::days(1)).unwrap(), //#[allow_ci]
                 ..Default::default()
             },
         )?;
@@ -265,17 +265,17 @@ mod tests {
     fn verify_cert_expiration_failure() -> anyhow::Result<()> {
         let ca_data = generate_certificate(None, CertGenerationOptions::default())?;
 
-        let integrated_time = Utc::now().checked_add_signed(Duration::days(5)).unwrap();
+        let integrated_time = Utc::now().checked_add_signed(Duration::days(5)).unwrap(); //#[allow_ci]
 
         let issued_cert = generate_certificate(
             Some(&ca_data),
             CertGenerationOptions {
-                not_before: Utc::now().checked_sub_signed(Duration::days(1)).unwrap(),
-                not_after: Utc::now().checked_add_signed(Duration::days(1)).unwrap(),
+                not_before: Utc::now().checked_sub_signed(Duration::days(1)).unwrap(), //#[allow_ci]
+                not_after: Utc::now().checked_add_signed(Duration::days(1)).unwrap(), //#[allow_ci]
                 ..Default::default()
             },
         )?;
-        let issued_cert_pem = issued_cert.cert.to_pem().unwrap();
+        let issued_cert_pem = issued_cert.cert.to_pem().unwrap(); //#[allow_ci]
         let (_, pem) = x509_parser::pem::parse_x509_pem(&issued_cert_pem)?;
         let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 //!           unsatisfied_constraints,
 //!       }) => {
 //!           println!("{:?}", unsatisfied_constraints);
-//!           panic!("Image verification failed")
+//!           panic!("Image verification failed") //#[allow_ci]
 //!       }
 //!   }
 //! }

--- a/src/oauth/openidflow.rs
+++ b/src/oauth/openidflow.rs
@@ -280,7 +280,7 @@ fn test_auth_url() {
         "http://localhost:8080",
     )
     .auth_url();
-    let oidc_url = oidc_url.unwrap();
+    let oidc_url = oidc_url.unwrap(); //#[allow_ci]
     assert!(oidc_url
         .0
         .to_string()

--- a/src/simple_signing.rs
+++ b/src/simple_signing.rs
@@ -192,7 +192,7 @@ mod tests {
                 }
             }
         });
-        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap();
+        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap(); //#[allow_ci]
 
         let mut annotations: HashMap<String, String> = HashMap::new();
         annotations.insert(String::from("env"), String::from("prod"));
@@ -213,7 +213,7 @@ mod tests {
                 }
             }
         });
-        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap();
+        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap(); //#[allow_ci]
         let annotations: HashMap<String, String> = HashMap::new();
 
         assert!(ss.satisfies_annotations(&annotations));
@@ -231,7 +231,7 @@ mod tests {
             "number": 1,
             "bool": true
         });
-        let optional: Optional = serde_json::from_value(optional_json).unwrap();
+        let optional: Optional = serde_json::from_value(optional_json).unwrap(); //#[allow_ci]
 
         assert!(optional.satisfies_annotations(&annotations));
     }
@@ -246,7 +246,7 @@ mod tests {
             "owner": "flavio",
             "team": "devops"
         });
-        let optional: Optional = serde_json::from_value(optional_json).unwrap();
+        let optional: Optional = serde_json::from_value(optional_json).unwrap(); //#[allow_ci]
 
         assert!(!optional.satisfies_annotations(&annotations));
     }
@@ -262,7 +262,7 @@ mod tests {
             "owner": "flavio",
             "team": "devops"
         });
-        let optional: Optional = serde_json::from_value(optional_json).unwrap();
+        let optional: Optional = serde_json::from_value(optional_json).unwrap(); //#[allow_ci]
 
         assert!(!optional.satisfies_annotations(&annotations));
     }
@@ -276,7 +276,7 @@ mod tests {
             "owner": "flavio",
             "team": "devops"
         });
-        let optional: Optional = serde_json::from_value(optional_json).unwrap();
+        let optional: Optional = serde_json::from_value(optional_json).unwrap(); //#[allow_ci]
 
         assert!(optional.satisfies_annotations(&annotations));
     }
@@ -295,7 +295,7 @@ mod tests {
                 }
             }
         });
-        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap();
+        let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap(); //#[allow_ci]
 
         assert!(ss.satisfies_manifest_digest(expected_digest));
         assert!(!ss.satisfies_manifest_digest("something different"));

--- a/tests/ban-list.py
+++ b/tests/ban-list.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script checks the src directory for instances of unwrap / panic
+# legimate uses can be overridden by commenting: //#[allow_ci]
+
+import os
+
+banned = ["unwrap(", "panic!(", "unsafe"]
+
+for root, dirs, files in os.walk("src", topdown=False):
+   for name in files:
+      with open(os.path.join(root, name)) as src_file:
+            for line_no, line in enumerate(src_file):
+                for b in banned:
+                    if b not in line or "//#[allow_ci]" in line:
+                        continue
+                    failed = True
+                    print("File %s on line number: %s calls banned function: %s)" % (os.path.join(root, name), line_no + 1, b))
+                continue
+exit(failed)


### PR DESCRIPTION
Performs a search of the `src` directory (not `examples` etc) for
the terms that can be problematic in production code.

If a term is used legitimately, the use can be skipped:

`something.unwrap(); //#[allow_ci]`

I have currently commented out all instances in test code or where
a comment is provided to explain why use of function is acceptable

Signed-off-by: Luke Hinds <lhinds@redhat.com>