### PR TITLE
Block unsafe and have clippy warn on unsafe|panic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,4 +62,4 @@ jobs:
       - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: --workspace -- -D warnings
+          args: --workspace -- -D warnings -D clippy::unwrap_used -D clippy::panic  

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,4 +62,4 @@ jobs:
       - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: --workspace -- -D warnings -D clippy::unwrap_used -D clippy::panic  
+          args: --workspace -- -D warnings

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -246,19 +246,22 @@ impl SignatureLayer {
             None => return Ok(None),
         };
 
-        if fulcio_cert_pool.is_none() {
-            return Err(SigstoreError::SigstoreFulcioCertificatesNotProvidedError);
-        }
+        let fulcio_cert_pool = match fulcio_cert_pool {
+            Some(cp) => cp,
+            None => {
+                return Err(SigstoreError::SigstoreFulcioCertificatesNotProvidedError);
+            }
+        };
 
-        if bundle.is_none() {
-            return Err(SigstoreError::SigstoreRekorBundleNotFoundError);
-        }
+        let bundle = match bundle {
+            Some(b) => b,
+            None => {
+                return Err(SigstoreError::SigstoreRekorBundleNotFoundError);
+            }
+        };
 
-        let certificate_signature = CertificateSignature::from_certificate(
-            cert_raw.as_bytes(),
-            fulcio_cert_pool.unwrap(),
-            bundle.unwrap(),
-        )?;
+        let certificate_signature =
+            CertificateSignature::from_certificate(cert_raw.as_bytes(), fulcio_cert_pool, bundle)?;
         Ok(Some(certificate_signature))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@
 //! directory.
 
 #![forbid(unsafe_code)]
+#![warn(clippy::unwrap_used, clippy::panic)]
 
 pub mod crypto;
 mod mock_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,8 @@
 //! Additional examples can be found inside of the [`examples`](https://github.com/sigstore/sigstore-rs/tree/main/examples/)
 //! directory.
 
+#![forbid(unsafe_code)]
+
 pub mod crypto;
 mod mock_client;
 

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -81,6 +81,7 @@ impl<'a> PullSettings<'a> {
         }
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn image(&self) -> oci_distribution::Reference {
         // we can use `unwrap` here, because this will never fail
         let reference: oci_distribution::Reference = self.image.parse().unwrap();
@@ -171,6 +172,7 @@ impl PullManifestSettings {
         }
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn image(&self) -> oci_distribution::Reference {
         // we can use `unwrap` here, because this will never fail
         let reference: oci_distribution::Reference = self.image.parse().unwrap();

--- a/src/simple_signing.rs
+++ b/src/simple_signing.rs
@@ -30,7 +30,14 @@ pub struct SimpleSigning {
 
 impl fmt::Display for SimpleSigning {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", serde_json::to_string_pretty(self).unwrap())
+        write!(
+            f,
+            "{}",
+            serde_json::to_string_pretty(self).map_err(|e| {
+                error!(error=?e, simple_signing=?self, "Cannot convert to JSON");
+                fmt::Error
+            })?
+        )
     }
 }
 
@@ -42,12 +49,8 @@ impl SimpleSigning {
             return true;
         }
 
-        match self.optional {
-            Some(_) => self
-                .optional
-                .clone()
-                .unwrap()
-                .satisfies_annotations(annotations),
+        match &self.optional {
+            Some(opt) => opt.satisfies_annotations(annotations),
             None => {
                 info!(
                     simple_signing=?self,

--- a/src/tuf/constants.rs
+++ b/src/tuf/constants.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 
 lazy_static! {
     pub(crate) static ref SIGSTORE_FULCIO_CERT_TARGET_REGEX: Regex =
-        Regex::new(r#"fulcio(_v\d+)?\.crt\.pem"#).unwrap();
+        Regex::new(r#"fulcio(_v\d+)?\.crt\.pem"#).expect("cannot compile regexp");
 }
 
 pub(crate) const SIGSTORE_METADATA_BASE: &str = "http://sigstore-tuf-root.storage.googleapis.com/";


### PR DESCRIPTION
I added exceptions to instances of unwrap that have a comment
justifying use.

We now need to either toggle the last to handling the Option / Result or
use except.

Test uses of unwrap will be ignored (as will examples)

Blocks unsafe

Signed-off-by: Luke Hinds <lhinds@redhat.com>
