### PR TITLE
Extract all the GitHub related information from signature certs

### DIFF
--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -26,6 +26,7 @@ use crate::{
     crypto::certificate_pool::CertificatePool,
     errors::{Result, SigstoreError},
 };
+use tracing::debug;
 
 /// Cosign Client
 ///
@@ -83,13 +84,16 @@ impl CosignCapabilities for Client {
             }
         };
 
-        build_signature_layers(
+        let sl = build_signature_layers(
             &image_manifest,
             source_image_digest,
             &layers,
             self.rekor_pub_key.as_ref(),
             self.fulcio_cert_pool.as_ref(),
-        )
+        )?;
+
+        debug!(signature_layers=?sl, ?cosign_image, "trusted signature layers");
+        Ok(sl)
     }
 }
 

--- a/src/cosign/constants.rs
+++ b/src/cosign/constants.rs
@@ -16,6 +16,14 @@
 use x509_parser::der_parser::{oid, oid::Oid};
 
 pub(crate) const SIGSTORE_ISSUER_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .1);
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_TRIGGER_OID: Oid<'static> =
+    oid!(1.3.6 .1 .4 .1 .57264 .1 .2);
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_SHA_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .3);
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_NAME_OID: Oid<'static> =
+    oid!(1.3.6 .1 .4 .1 .57264 .1 .4);
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REPOSITORY_OID: Oid<'static> =
+    oid!(1.3.6 .1 .4 .1 .57264 .1 .5);
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REF_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .6);
 
 pub(crate) const SIGSTORE_OCI_MEDIA_TYPE: &str = "application/vnd.dev.cosign.simplesigning.v1+json";
 pub(crate) const SIGSTORE_SIGNATURE_ANNOTATION: &str = "dev.cosignproject.cosign/signature";


### PR DESCRIPTION
The certificates issued by Fulcio include some custom x509 extensions when `cosign verify` is ran inside of a GitHub Action.

Starting from this commit, all these extra attributes are extracted from the certificate and stored inside of the `CertificateSignature` object.

This allows the creation of more fine-tuned validation constraints for signatures produced inside of GitHub Actions.
