### PR TITLE
Release v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = [
   "sigstore-rs developers",
 ]
+license = "Apache-2.0"
+readme = "README.md"
 
 [features]
 default = ["native-tls"]

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ Signature annotations and certificate email can be provided at verification time
 
 #### Known limitations
 
-* Users must provide the public key of the transparency log (Rekor) and the
-  certificate of the PKI (Fulcio). The removal of this limitation is tracked
-  by [this issue](https://github.com/sigstore/sigstore-rs/issues/9).
 * The crate does not handle verification of attestations yet.
 
 ## Examples


### PR DESCRIPTION
Add a `license` entry inside of Cargo.toml. This is needed in order to publish the crate on creates.io


Unfortunately `cargo publish --dry-run` doesn't report this issue, this is something enforced by crates.io at "push" time