### PR TITLE
fix broken ci

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2020-0071", # `time` localtime_r segfault -- https://rustsec.org/advisories/RUSTSEC-2020-0071
+                       # This vulnerability is currently not affecting chrono 0.4.20+
+                       # See https://github.com/chronotope/chrono/issues/602
+                       # Chrono 0.5 will upgrade this depependency, but this will lead
+                       # to API breakages.
+                       #
+                       # This is a transitive depependency of tough
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ olpc-cjson = "0.1.1"
 open = "3.0.1"
 openidconnect = { version = "2.2.0", default-features = false, features = [ "reqwest" ] }
 pem = "1.0.2"
-picky = { version = "7.0.0-rc.2", default-features = false, features = [ "x509" ] }
+picky = { version = "7.0.0-rc.3", default-features = false, features = [ "x509", "ec" ] }
 regex = "1.5.5"
 ring = "0.16.20"
 serde_json = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 oci-distribution = { version = "0.9.0", default-features = false }
 olpc-cjson = "0.1.1"
 open = "3.0.1"
-openidconnect = { version = "2.2.0", default-features = false, features = [ "reqwest" ] }
+openidconnect = { version = "2.3", default-features = false, features = [ "reqwest" ] }
 pem = "1.0.2"
 picky = { version = "7.0.0-rc.3", default-features = false, features = [ "x509", "ec" ] }
 regex = "1.5.5"
@@ -40,7 +40,7 @@ x509-parser = { version = "0.14.0", features = ["verify"] }
 
 [dev-dependencies]
 anyhow = "1.0.54"
-chrono = "0.4.19"
+chrono = "0.4.20"
 clap = { version = "3.1.0", features = ["derive"] }
 openssl = "0.10.38"
 rstest = "0.15.0"


### PR DESCRIPTION
This PR fixes the broken unit tests and makes `cargo audit` happy.

## Broken unit tests

They were failing because the `picky` crate was not built with the `ec` feature enabled. That caused the verification of all the certificates using ECDSA keys to fail.

## Cargo audit report

Cargo audit was previously failing because of two rust security issues:

* [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159): this affected chrono release prior to 0.4.19.
* [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071): this is an issue affecting old release of the `time` crate


chrono release 0.4.20 fixes the first issue ([RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159)).
However, chrono dependency on the old time 0.1 release is still present, which makes `cargo audit` report the second issue ([RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071)).

According to [chrono 0.4.20 release notes](https://github.com/chronotope/chrono/releases/tag/v0.4.20):

> Due to compatibility reasons, this release does not yet remove the time 0.1 dependency, though chrono 0.4.20 does not depend on the vulnerable parts of the time 0.1.x versions. In a future 0.5 release, we will remove the time dependency.

Until chrono 0.5.0 is released, I've configured `cargo audit` to ignore the [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071) issue.

This PR upgrades the openidconnect crate to a more recent release. This crate depends on chrono as well, but it doesn't need the features provided by the time 0.1 library.
The more recent version of openidconnect connect is configured to disable the `clock` feature of chrono, which basically removes the `time` dependency from it.
This is not enough to remove the [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071) warning (because tough cannot be built without the `clock` feature of chrono), but it's a small cleanup that makes me feel better :)
