### PR TITLE
Tag v0.3.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 authors = [
   "sigstore-rs developers",


### PR DESCRIPTION
Changes since v0.3.2:

* Ensure certificates using ECDSA keys keep working (bf908074203326e9d51c8ad7ee8c4298149cee66)
* Extend README to cover OIDC usage
* Update dependencies

I think we should really push out a new release to ensure certificate verification keeps working.
