### PR TITLE
Add RUSTSEC-2021-0139 to audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,7 @@ ignore = [
                        # to API breakages.
                        #
                        # This is a transitive depependency of tough
+  "RUSTSEC-2021-0139"  # ansi_term is no longer maintained, however this is a transient dependency of
+                       # the `tracing-subscriber` crate, which is a dev_dependency and so therefore
+                       # will not be included in a release build.
 ]


### PR DESCRIPTION
Security CI runs are failing due to RUSTSEC-2021-0139

RUSTSEC-2021-0139 is flagged from ansi_term, which is a transient
dependency on tracing-subscriber. As tracing-subscriber is a
dev-dependency, I think we can safely add this to the ignore flag.

No vulnerabilities exist in ansi-term, the warning is there as the crate is
unmaintained at present.

Signed-off-by: Luke Hinds <lhinds@redhat.com>