### PR TITLE
chore: relax some dependencies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ async-trait = "0.1.52"
 base64 = "0.13.0"
 cached = "0.39.0"
 lazy_static = "1.4.0"
-oci-distribution = { version = "0.9.0", default-features = false }
-olpc-cjson = "0.1.1"
+oci-distribution = { version = "0.9", default-features = false }
+olpc-cjson = "0.1"
 open = "3.0.1"
 openidconnect = { version = "2.3", default-features = false, features = [ "reqwest" ] }
 pem = "1.0.2"
@@ -32,7 +32,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 sha2 = "0.10.2"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["full"] }
-tough = { version = "0.12.4", features = [ "http" ] }
+tough = { version = "0.12", features = [ "http" ] }
 tracing = "0.1.31"
 url = "2.2.2"
 x509-parser = { version = "0.14.0", features = ["verify"] }


### PR DESCRIPTION
Require only major and minor version, don't have the patch release hardcoded.

This is done to the following dependencies:

  * oci-distribution
  * olpc-cjson
  * tough
