### PR TITLE
fix verification of signatures produced with pki11

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -111,7 +111,7 @@ async fn run_app(
     let mut client_builder = sigstore::cosign::ClientBuilder::default();
 
     if let Some(key) = frd.rekor_pub_key.as_ref() {
-        client_builder = client_builder.with_rekor_pub_key(&key);
+        client_builder = client_builder.with_rekor_pub_key(key);
     }
 
     if !frd.fulcio_certs.is_empty() {

--- a/examples/openidflow/openidconnect/main.rs
+++ b/examples/openidflow/openidconnect/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), anyhow::Error> {
             open::that(url.0.to_string())?;
             println!(
                 "Open this URL in a browser if it does not automatically open for you:\n{}\n",
-                url.0.to_string()
+                url.0
             );
         }
         Err(e) => println!("{}", e),

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -67,14 +67,31 @@ pub trait CosignCapabilities {
     /// Returns the list of [`SignatureLayer`](crate::cosign::signature_layers::SignatureLayer)
     /// objects that are associated with the given signature object.
     ///
-    /// When Fulcio's integration has been enabled, the returned `SignatureLayer`
-    /// objects have been verified using the certificates bundled inside of the
-    /// signature image. All these certificates have been issues by Fulcio's CA.
+    /// Each layer is verified, to ensure it contains legitimate data.
     ///
-    /// When Rekor's integration is enabled, the [`SignatureLayer`] objects have
-    /// been successfully verified using the Bundle object found inside of the
-    /// signature image. All the Bundled objects have been verified using Rekor's
-    /// signature.
+    /// ## Layers with embedded certificate
+    ///
+    /// A signature can contain a certificate, this happens when signatures
+    /// are produced in keyless mode or when a PKCS11 tokens are used.
+    ///
+    /// The certificate is added to [`SignatureLayer::certificate_signature`]
+    /// only when it can be trusted.
+    ///
+    /// In order to trust an embedded certificate, the following prerequisites
+    /// must be satisfied:
+    ///
+    /// * The [`sigstore::cosign::Client`](crate::cosign::client::Client) must
+    ///   have been created with Rekor integration enabled (see
+    ///   [`sigstore::cosign::ClientBuilder::with_rekor_pub_key`](crate::cosign::ClientBuilder::with_rekor_pub_key))
+    /// * The [`sigstore::cosign::Client`](crate::cosign::client::Client) must
+    ///   have been created with Fulcio integration enabled (see
+    ///   [`sigstore::cosign::ClientBuilder::with_fulcio_certs`](crate::cosign::ClientBuilder::with_fulcio_certs))
+    /// * The layer must include a bundle produced by Rekor
+    ///
+    /// When the embedded certificate cannot be verified, [`SignatureLayer::certificate_signature`]
+    /// is going to be `None`.
+    ///
+    /// ## Usage
     ///
     /// These returned objects can then be verified against
     /// [`VerificationConstraints`](crate::cosign::verification_constraint::VerificationConstraint)

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -173,8 +173,6 @@ impl SignatureLayer {
     ///     entries
     ///   * `fulcio_pub_key`: the public key provided by Fulcio's certificate.
     ///     Used to verify the `certificate` entries
-    ///   * `cert_email`: optional, the SAN to look for inside of trusted
-    ///     certificates issued by Fulcio
     ///
     /// **Note well:** the certificate and bundle added to the final SignatureLayer
     /// object are to be considered **trusted** and **verified**, according to

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -238,7 +238,7 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
         let public_key = private_key.public_key();
 
         let ec_pub_key =
-            EcKey::from_public_key(&group, &public_key).expect("Cannot create ec pub key");
+            EcKey::from_public_key(&group, public_key).expect("Cannot create ec pub key");
         let pkey = pkey::PKey::from_ec_key(ec_pub_key).expect("Cannot create pkey");
 
         let mut x509_name_builder = X509NameBuilder::new()?;
@@ -369,7 +369,7 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
         // set issuer
         if let Some(issuer_data) = issuer {
             let issuer_name = issuer_data.cert.subject_name();
-            x509_builder.set_issuer_name(&issuer_name)?;
+            x509_builder.set_issuer_name(issuer_name)?;
         } else {
             // self signed cert
             x509_builder.set_issuer_name(&x509_name)?;

--- a/src/crypto/signing_key/mod.rs
+++ b/src/crypto/signing_key/mod.rs
@@ -340,10 +340,9 @@ mod tests {
     #[case(SigningScheme::ECDSA_P384_SHA384_ASN1)]
     #[case(SigningScheme::ED25519)]
     fn sigstore_signing(#[case] signing_scheme: SigningScheme) {
-        let signer = signing_scheme.create_signer().expect(&format!(
-            "create SigStoreSigner with {:?} failed",
-            signing_scheme
-        ));
+        let signer = signing_scheme
+            .create_signer()
+            .unwrap_or_else(|_| panic!("create SigStoreSigner with {:?} failed", signing_scheme));
         let key_pair = signer
             .to_sigstore_keypair()
             .expect("convert SigStoreSigner to SigStoreKeypair failed.");

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -288,7 +288,7 @@ mod tests {
                 .expect("Cannot create CosignVerificationKey");
         let msg = r#"{"critical":{"identity":{"docker-reference":"registry-testing.svc.lan/busybox"},"image":{"docker-manifest-digest":"sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b"},"type":"cosign container image signature"},"optional":null}"#;
 
-        let outcome = verification_key.verify_signature(signature, &msg.as_bytes());
+        let outcome = verification_key.verify_signature(signature, msg.as_bytes());
         assert!(outcome.is_ok());
     }
 
@@ -301,7 +301,7 @@ mod tests {
         let msg = "hello world";
 
         let err = verification_key
-            .verify_signature(signature, &msg.as_bytes())
+            .verify_signature(signature, msg.as_bytes())
             .expect_err("Was expecting an error");
         let found = match err {
             SigstoreError::PublicKeyVerificationError => true,
@@ -319,7 +319,7 @@ mod tests {
         let msg = r#"{"critical":{"identity":{"docker-reference":"registry-testing.svc.lan/busybox"},"image":{"docker-manifest-digest":"sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b"},"type":"cosign container image signature"},"optional":null}"#;
 
         let err = verification_key
-            .verify_signature(signature, &msg.as_bytes())
+            .verify_signature(signature, msg.as_bytes())
             .expect_err("Was expecting an error");
         let found = match err {
             SigstoreError::Base64DecodeError(_) => true,
@@ -344,7 +344,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
         let msg = r#"{"critical":{"identity":{"docker-reference":"registry-testing.svc.lan/busybox"},"image":{"docker-manifest-digest":"sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b"},"type":"cosign container image signature"},"optional":null}"#;
 
         let err = verification_key
-            .verify_signature(signature, &msg.as_bytes())
+            .verify_signature(signature, msg.as_bytes())
             .expect_err("Was expecting an error");
         let found = match err {
             SigstoreError::PublicKeyVerificationError => true,
@@ -374,7 +374,7 @@ DwIDAQAB
         let msg = r#"{"critical":{"identity":{"docker-reference":"registry.suse.com/suse/sle-micro/5.0/toolbox"},"image":{"docker-manifest-digest":"sha256:356631f7603526a0af827741f5fe005acf19b7ef7705a34241a91c2d47a6db5e"},"type":"cosign container image signature"},"optional":{"creator":"OBS"}}"#;
 
         assert!(verification_key
-            .verify_signature(signature, &msg.as_bytes())
+            .verify_signature(signature, msg.as_bytes())
             .is_ok());
     }
 }

--- a/src/rekor/apis/entries_api.rs
+++ b/src/rekor/apis/entries_api.rs
@@ -52,7 +52,7 @@ pub enum SearchLogQueryError {
     UnknownValue(serde_json::Value),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntries {
     entries: Vec<LogEntry>,

--- a/src/rekor/models/alpine.rs
+++ b/src/rekor/models/alpine.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Alpine : Alpine package
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Alpine {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/alpine_all_of.rs
+++ b/src/rekor/models/alpine_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AlpineAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/consistency_proof.rs
+++ b/src/rekor/models/consistency_proof.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ConsistencyProof {
     /// The hash value stored at the root of the merkle tree at the time the proof was generated
     #[serde(rename = "rootHash")]

--- a/src/rekor/models/error.rs
+++ b/src/rekor/models/error.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Error {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,

--- a/src/rekor/models/hashedrekord.rs
+++ b/src/rekor/models/hashedrekord.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 /// Hashedrekord : Hashed Rekord object
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Hashedrekord {
     #[serde(rename = "kind")]
     pub kind: String,
@@ -35,7 +35,7 @@ impl Hashedrekord {
 }
 
 /// Stores the Signature and Data struct
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spec {
     signature: Signature,
@@ -50,7 +50,7 @@ impl Spec {
 }
 
 /// Stores the signature format, signature of the artifact and the PublicKey struct
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Signature {
     format: String,
@@ -69,7 +69,7 @@ impl Signature {
 }
 
 /// Stores the public key used to sign the artifact
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     content: String,
@@ -81,7 +81,7 @@ impl PublicKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
     hash: Hash,
@@ -94,7 +94,7 @@ impl Data {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum AlgorithmKind {
     sha256,
@@ -102,7 +102,7 @@ pub enum AlgorithmKind {
 }
 
 /// Stores the algorithm used to hash the artifact and the value of the hash
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hash {
     algorithm: AlgorithmKind,

--- a/src/rekor/models/hashedrekord_all_of.rs
+++ b/src/rekor/models/hashedrekord_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct HashedrekordAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/helm.rs
+++ b/src/rekor/models/helm.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// Helm : Helm chart
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Helm {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/helm_all_of.rs
+++ b/src/rekor/models/helm_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct HelmAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/inactive_shard_log_info.rs
+++ b/src/rekor/models/inactive_shard_log_info.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct InactiveShardLogInfo {
     /// The current hash value stored at the root of the merkle tree
     #[serde(rename = "rootHash")]

--- a/src/rekor/models/inclusion_proof.rs
+++ b/src/rekor/models/inclusion_proof.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct InclusionProof {
     /// The index of the entry in the transparency log
     #[serde(rename = "logIndex")]

--- a/src/rekor/models/intoto.rs
+++ b/src/rekor/models/intoto.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// Intoto : Intoto object
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Intoto {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/intoto_all_of.rs
+++ b/src/rekor/models/intoto_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct IntotoAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/jar.rs
+++ b/src/rekor/models/jar.rs
@@ -11,7 +11,7 @@
 /// Jar : Java Archive (JAR)
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Jar {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/jar_all_of.rs
+++ b/src/rekor/models/jar_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct JarAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/log_entry.rs
+++ b/src/rekor/models/log_entry.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Stores the response returned by Rekor after making a new entry
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntry {
     uuid: String,
@@ -14,7 +14,7 @@ pub struct LogEntry {
     verification: Verification,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Attestation {
     // This field is just a place holder
@@ -24,7 +24,7 @@ pub struct Attestation {
 }
 
 /// Stores the signature over the artifact's logID, logIndex, body and integratedTime.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Verification {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,7 +33,7 @@ pub struct Verification {
 }
 
 /// Stores the signature over the artifact's logID, logIndex, body and integratedTime.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InclusionProof {
     hashes: Vec<String>,

--- a/src/rekor/models/log_info.rs
+++ b/src/rekor/models/log_info.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct LogInfo {
     /// The current hash value stored at the root of the merkle tree
     #[serde(rename = "rootHash")]

--- a/src/rekor/models/proposed_entry.rs
+++ b/src/rekor/models/proposed_entry.rs
@@ -9,7 +9,7 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum ProposedEntry {
     #[serde(rename = "alpine")]

--- a/src/rekor/models/rekord.rs
+++ b/src/rekor/models/rekord.rs
@@ -11,7 +11,7 @@
 /// Rekord : Rekord object
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Rekord {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/rekord_all_of.rs
+++ b/src/rekor/models/rekord_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct RekordAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/rfc3161.rs
+++ b/src/rekor/models/rfc3161.rs
@@ -11,7 +11,7 @@
 /// Rfc3161 : RFC3161 Timestamp
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Rfc3161 {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/rfc3161_all_of.rs
+++ b/src/rekor/models/rfc3161_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Rfc3161AllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/rpm.rs
+++ b/src/rekor/models/rpm.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// Rpm : RPM package
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Rpm {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/rpm_all_of.rs
+++ b/src/rekor/models/rpm_all_of.rs
@@ -9,7 +9,7 @@
  */
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct RpmAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/rekor/models/search_index.rs
+++ b/src/rekor/models/search_index.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SearchIndex {
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,

--- a/src/rekor/models/search_index_public_key.rs
+++ b/src/rekor/models/search_index_public_key.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SearchIndexPublicKey {
     #[serde(rename = "format")]
     pub format: Format,

--- a/src/rekor/models/search_log_query.rs
+++ b/src/rekor/models/search_log_query.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct SearchLogQuery {
     #[serde(rename = "entryUUIDs", skip_serializing_if = "Option::is_none")]
     pub entry_uuids: Option<Vec<String>>,

--- a/src/rekor/models/tuf.rs
+++ b/src/rekor/models/tuf.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// Tuf : TUF metadata
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Tuf {
     #[serde(rename = "kind")]
     pub kind: String,

--- a/src/rekor/models/tuf_all_of.rs
+++ b/src/rekor/models/tuf_all_of.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct TufAllOf {
     #[serde(rename = "apiVersion")]
     pub api_version: String,

--- a/src/tuf/repository_helper.rs
+++ b/src/tuf/repository_helper.rs
@@ -278,7 +278,7 @@ mod tests {
                             .join("targets")
                             .join(filename),
                     )
-                    .expect(format!("cannot read {} from test data", filename).as_str());
+                    .unwrap_or_else(|_| panic!("cannot read {} from test data", filename));
                     crate::registry::Certificate {
                         data,
                         encoding: crate::registry::CertificateEncoding::Pem,
@@ -329,7 +329,7 @@ mod tests {
                             .join("targets")
                             .join(filename),
                     )
-                    .expect(format!("cannot read {} from test data", filename).as_str());
+                    .unwrap_or_else(|_| panic!("cannot read {} from test data", filename));
                     crate::registry::Certificate {
                         data,
                         encoding: crate::registry::CertificateEncoding::Pem,
@@ -358,7 +358,7 @@ mod tests {
         let cache_dir = TempDir::new().expect("Cannot create temp cache dir");
 
         // put some outdated files inside of the cache
-        for filename in vec!["fulcio.crt.pem", "fulcio_v1.crt.pem"] {
+        for filename in &["fulcio.crt.pem", "fulcio_v1.crt.pem"] {
             fs::write(cache_dir.path().join(filename), b"fake fulcio")
                 .expect("Cannot write file to cache dir");
         }
@@ -386,7 +386,7 @@ mod tests {
                             .join("targets")
                             .join(filename),
                     )
-                    .expect(format!("cannot read {} from test data", filename).as_str());
+                    .unwrap_or_else(|_| panic!("cannot read {} from test data", filename));
                     crate::registry::Certificate {
                         data,
                         encoding: crate::registry::CertificateEncoding::Pem,


### PR DESCRIPTION
The `cosign` tool can produce signatures using a PKCS11 token. These signatures feature a `certificate` annotation inside of their OCI layer.

However, when `COSIGN_EXPERIMENTAL` is not enabled, the layer will not feature a Rekor bundle.

Prior to this commit, the code assumed signature layers could have a `certificate` annotation only when using the Fulcio integration. Because of that, layers with a `certificate` but without a Rekor bundle were discarded. That was done to ensure the robustness of keyless verification.

This commit changes the code that creates `SignatureLayer` objects to not raise errors when an embedded certificate cannot be verified. Be it because it has been forged/invalid/etc or because the Rekor bundle is not found inside of the layer.

The resulting `SignatureLayer` will not be discarded, but it will have its `certificate_signature` attribute set to `None`.

> **Note:** `SignatureLayer::certificate_signature` was already a `Option` before of this commit.

The verification constraints implementing keyless verification will discard these kind of layers because they do not have a `certificate_signature`.

However, the public key based verifier will be able to verify the signature stored inside of the layer.

This solves the following scenario:

> Given Alice signed a container image using a PKCS11 token but without having cosign's Rekor integration enabled
> When verifying the container image signature using the public key associated with the certificate stored on her PKCS11 token
> Then the container image will be reported as successfully verified

Fixes https://github.com/sigstore/sigstore-rs/issues/135

