### PR TITLE
fix: address compilation error

### DIFF
--- a/src/fulcio/mod.rs
+++ b/src/fulcio/mod.rs
@@ -5,7 +5,6 @@ use crate::crypto::SigningScheme;
 use crate::errors::{Result, SigstoreError};
 use crate::fulcio::oauth::OauthTokenProvider;
 use openidconnect::core::CoreIdToken;
-use reqwest::header::HeaderName;
 use reqwest::Body;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
@@ -19,7 +18,7 @@ pub const FULCIO_ROOT: &str = "https://fulcio.sigstore.dev/";
 /// Path within Fulcio to obtain a signing certificate.
 pub const SIGNING_CERT_PATH: &str = "api/v1/signingCert";
 
-const CONTENT_TYPE_HEADER_NAME: HeaderName = HeaderName::from_static("content-type");
+const CONTENT_TYPE_HEADER_NAME: &str = "content-type";
 
 /// Fulcio certificate signing request
 ///


### PR DESCRIPTION
For some unexplained reasons, using the library inside of another project caused this error:

```console
error[E0015]: cannot call non-const fn `HeaderName::from_static` in constants
  --> /home/flavio/.cargo/registry/src/github.com-1ecc6299db9ec823/sigstore-0.5.1/src/fulcio/mod.rs:22:46
   |
22 | const CONTENT_TYPE_HEADER_NAME: HeaderName = HeaderName::from_static("content-type");
   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: calls in constants are limited to constant functions, tuple structs and tuple variants

For more information about this error, try `rustc --explain E0015`.
```

This happened with sigstore-rs >= 0.5, but it was not detected by cargo check despite the same version of rustc and rust edition is used.

This commit addresses the compilation error.
