### PR TITLE
fix: rustls should not require openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 authors = [
   "sigstore-rs developers",
@@ -11,8 +11,8 @@ readme = "README.md"
 
 [features]
 default = ["native-tls"]
-native-tls = ["oci-distribution/native-tls", "openidconnect/native-tls"]
-rustls-tls = ["oci-distribution/rustls-tls", "openidconnect/rustls-tls"]
+native-tls = ["oci-distribution/native-tls", "openidconnect/native-tls", "reqwest/native-tls"]
+rustls-tls = ["oci-distribution/rustls-tls", "openidconnect/rustls-tls", "reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1.52"
@@ -50,6 +50,7 @@ ed25519 = { version = "1", features = [ "alloc" ] }
 ed25519-dalek-fiat = "0.1.0"
 rsa = "0.7.0"
 pkcs1 = "0.4.0"
+reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"] }
 
 [dev-dependencies]
 anyhow = "1.0.54"
@@ -61,9 +62,6 @@ rstest = "0.15.0"
 tempfile = "3.3.0"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 
-[dependencies.reqwest]
-version = "^0.11"
-features = ["json", "multipart"]
 
 # cosign example mappings
 


### PR DESCRIPTION
Ensure the openssl dependency is not introduced when the sigstore-rs library is built using rustls-tls.
