### PR TITLE
Set tag to COSIGN_PRIVATE_KEY_PEM_LABEL for ec.rs

### DIFF
--- a/src/crypto/signing_key/ecdsa/ec.rs
+++ b/src/crypto/signing_key/ecdsa/ec.rs
@@ -259,7 +259,7 @@ where
                     .map_err(|e| SigstoreError::PKCS8DerError(e.to_string()))?,
             },
             _ => pem::Pem {
-                tag: SIGSTORE_PRIVATE_KEY_PEM_LABEL.to_string(),
+                tag: COSIGN_PRIVATE_KEY_PEM_LABEL.to_string(),
                 contents: kdf::encrypt(&der, password)?,
             },
         };


### PR DESCRIPTION


Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This commit suggests changing the tag used in `EcdsaKeys::private_key_to_encrypted_pem` from `SIGSTORE_PRIVATE_KEY_PEM_LABEL` to `COSIGN_PRIVATE_KEY_PEM_LABEL`.

The motivation for this is that using such a key with Go cosign will currently result in an `unsupported pem type` error. It seems like Go cosign is using [CosignPrivateKeyPemType](https://github.com/sigstore/cosign/blob/6b309df06f60ea5f58db22e9890713138c823d27/pkg/cosign/keys.go#L41) when [checking](https://github.com/sigstore/cosign/blob/6b309df06f60ea5f58db22e9890713138c823d27/pkg/cosign/keys.go#L208) the tag of the pem.

I'm not sure about the differences between
`SIGSTORE_PRIVATE_KEY_PEM_LABEL` and `COSIGN_PRIVATE_KEY_PEM_LABEL` and I might be missing something here but if the change in this PR is a valid then this should probably be done for rsa and ed25519 as well.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE