### PR TITLE
Fix incorrect base64_signature doc comment

### DIFF
--- a/src/cosign/bundle.rs
+++ b/src/cosign/bundle.rs
@@ -32,7 +32,7 @@ use crate::errors::{Result, SigstoreError};
 #[serde(rename_all = "camelCase")]
 pub struct SignedArtifactBundle {
     /// Represents the `base64Signature' field which is the signature of the
-    /// 'logIndex', 'body', and the 'integratedTime' fields.
+    /// of the blob.
     pub base64_signature: String,
     /// Represents the 'cert' field which is a PEM encoded certificate.
     pub cert: String,


### PR DESCRIPTION



<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This commit updates the doc comment for the base64_signature field which I believe is incorrect 
(I'm the one to blame for this, sorry!).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>
