### PR TITLE
Improve public key output and add file output

### DIFF
--- a/examples/rekor/get_public_key/main.rs
+++ b/examples/rekor/get_public_key/main.rs
@@ -47,10 +47,11 @@ async fn main() {
         &configuration,
         flags.get_one::<String>("tree_id").map(|s| s.as_str()),
     )
-    .await;
+    .await
+    .expect("Unable to retrieve public key");
 
     if let Some(out_path) = flags.get_one::<String>("output") {
-        match write(out_path, pubkey.unwrap()) {
+        match write(out_path, pubkey) {
             Ok(_) => (),
             Err(e) => {
                 eprintln!("Could not write to {out_path}: {e}");
@@ -58,6 +59,6 @@ async fn main() {
             }
         }
     } else {
-        print!("{}", pubkey.unwrap());
+        print!("{}", pubkey);
     }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As described in #105 the output provided by the example `get_public_key` was not pretty. It included quotation marks at the beginning and the and, as well as the newline characters `\n`. 
In addition this prevented piping the output of the example into a file, as it would include the quotation marks and the newline characters. Now using `cargo run --example get_public_key > key.pub` the public key can be stored in a file in the PEM format.

In addition it can be useful to directly store the public key in a file instead of piping to a file.  

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

The Rekor example `get_public_key` was expanded to:
* use `Display` printing 
* provide a command line option to store the public key in a file

#### Documentation

Close #105