### PR TITLE
fix: show actual response status field

### DIFF
--- a/src/rekor/apis/mod.rs
+++ b/src/rekor/apis/mod.rs
@@ -27,8 +27,13 @@ pub enum Error<T> {
         source: std::io::Error,
     },
 
-    #[error("error in response: status code {{error.status:?}}")]
+    #[error("error in response: status code {:?}", error_status(.0))]
     ResponseError(ResponseContent<T>),
+}
+
+#[inline]
+fn error_status<T>(response: &ResponseContent<T>) -> reqwest::StatusCode {
+    response.status
 }
 
 pub fn urlencode<T: AsRef<str>>(s: T) -> String {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Show the actual response status code, instead of `{error.status:?}`.

Currently, when a remote call fails with a client or server error, it shows a response error with the following message:

```
error in response: status code {{error.status:?}}
```

However, I do believe the actual intention (and what would be helpful), is to show the actual status code, instead of the literal string: `{error.status:?}`.

This PR fixes this issue, so that the error code gets shown.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fix an issue where, instead of the actual error code, the literal string `{error.status:?}` was shown.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->