### PR TITLE
fix: make the fields accessible

### DIFF
--- a/src/rekor/models/log_entry.rs
+++ b/src/rekor/models/log_entry.rs
@@ -50,16 +50,16 @@ pub struct Attestation {
 #[serde(rename_all = "camelCase")]
 pub struct Verification {
     #[serde(skip_serializing_if = "Option::is_none")]
-    inclusion_proof: Option<InclusionProof>,
-    signed_entry_timestamp: String,
+    pub inclusion_proof: Option<InclusionProof>,
+    pub signed_entry_timestamp: String,
 }
 
 /// Stores the signature over the artifact's logID, logIndex, body and integratedTime.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InclusionProof {
-    hashes: Vec<String>,
-    log_index: i64,
-    root_hash: String,
-    tree_size: TreeSize,
+    pub hashes: Vec<String>,
+    pub log_index: i64,
+    pub root_hash: String,
+    pub tree_size: TreeSize,
 }


### PR DESCRIPTION
Signed-off-by: Jens Reimann <jreimann@redhat.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Not having access to these fields makes it hard to work with the data (like verifying).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->