### PR TITLE
Changed the type of LogEntry.body from String to Body

### DIFF
--- a/src/rekor/apis/entries_api.rs
+++ b/src/rekor/apis/entries_api.rs
@@ -14,6 +14,7 @@ use super::{configuration, Error};
 use crate::rekor::apis::ResponseContent;
 use crate::rekor::models::log_entry::LogEntry;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// struct for typed errors of method [`create_log_entry`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -93,7 +94,7 @@ pub async fn create_log_entry(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<CreateLogEntryError> =
             serde_json::from_str(&local_var_content).ok();
@@ -130,7 +131,7 @@ pub async fn get_log_entry_by_index(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLogEntryByIndexError> =
             serde_json::from_str(&local_var_content).ok();
@@ -170,7 +171,7 @@ pub async fn get_log_entry_by_uuid(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLogEntryByUuidError> =
             serde_json::from_str(&local_var_content).ok();

--- a/src/rekor/models/hashedrekord.rs
+++ b/src/rekor/models/hashedrekord.rs
@@ -37,7 +37,7 @@ impl Hashedrekord {
 }
 
 /// Stores the Signature and Data struct
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spec {
     pub signature: Signature,
@@ -52,7 +52,7 @@ impl Spec {
 }
 
 /// Stores the signature format, signature of the artifact and the PublicKey struct
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Signature {
     pub content: String,
@@ -69,7 +69,7 @@ impl Signature {
 }
 
 /// Stores the public key used to sign the artifact
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     content: String,
@@ -86,7 +86,7 @@ impl PublicKey {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
     pub hash: Hash,
@@ -98,15 +98,16 @@ impl Data {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum AlgorithmKind {
+    #[default]
     sha256,
     sha1,
 }
 
 /// Stores the algorithm used to hash the artifact and the value of the hash
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hash {
     pub algorithm: AlgorithmKind,


### PR DESCRIPTION
Signed-off-by: Neccolini <shun11202991@gmail.com>

closes #150 

#### Summary
Enable detailed information to be obtained when a `LogEntry` is retrieved, whereas previously only encoded `String` was available for the `Body` information.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->