### PR TITLE
fix: bring tuf feature out of rekor and add related docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [features]
-default = ["full-native-tls", "cached-client"]
+default = ["full-native-tls", "cached-client", "tuf"]
 
 full-native-tls = ["fulcio-native-tls", "rekor-native-tls", "cosign-native-tls", "mock-client-native-tls"]
 full-rustls-tls = ["fulcio-rustls-tls", "rekor-rustls-tls", "cosign-rustls-tls", "mock-client-rustls-tls"]
@@ -28,7 +28,8 @@ oauth = []
 
 rekor-native-tls = [ "reqwest/native-tls", "rekor"]
 rekor-rustls-tls = [ "reqwest/rustls-tls", "rekor" ]
-rekor = [ "tuf" ]
+rekor = []
+
 tuf = [ "tough", "regex" ]
 
 cosign-native-tls = [ "oci-distribution/native-tls", "cert", "cosign", "registry-native-tls" ]

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -190,6 +190,7 @@ impl Client {
     }
 }
 
+#[cfg(feature = "mock-client")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,7 @@
 //! - `cached-client`: Enables support for OCI registry client caching.
 //!
 //! - `test-registry`: Enables tests based on a temporary OCI registry.
+//! - `tuf`: Enables support for TUF to request for fulcio certs and rekor public key.
 
 #![forbid(unsafe_code)]
 #![warn(clippy::unwrap_used, clippy::panic)]


### PR DESCRIPTION
Related to https://github.com/sigstore/sigstore-rs/issues/187
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
- TUF is a independent feature thus bring out of rekor
- Added `mock-client` feature to a test which depends on `mock-client`.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->