### PR TITLE
Replace `x509-parser` with `x509-cert`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ async-trait = "0.1.52"
 base64 = "0.21.0"
 cached = { version = "0.42.0", optional = true }
 cfg-if = "1.0.0"
+chrono = { version = "0.4.23", feature = "clock" }
+const-oid = "0.9.1"
+der = "0.6.1"
 digest = "0.10.3"
 ecdsa = { version = "0.15", features = [ "pkcs8", "digest", "der" ] }
 ed25519 = { version = "2", features = [ "alloc" ] }
@@ -71,7 +74,7 @@ pkcs8 = { version = "0.9.0", features = ["pem", "alloc", "pkcs5", "encryption"] 
 rand = { version = "0.8.5", features = [ "getrandom", "std" ] }
 regex = { version = "1.5.5", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"], optional = true}
-rsa = "0.8"
+rsa = "0.8.0"
 scrypt = "0.10.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
@@ -82,7 +85,7 @@ tokio = { version = "1.17.0", features = ["full"] }
 tough = { version = "0.12", features = [ "http" ], optional = true }
 tracing = "0.1.31"
 url = "2.2.2"
-x509-parser = { version = "0.14.0", features = ["verify"] }
+x509-cert = { version = "0.1.1", features = [ "pem", "std" ] }
 xsalsa20poly1305 = "0.9.0"
 zeroize = "1.5.7"
 

--- a/src/cosign/bundle.rs
+++ b/src/cosign/bundle.rs
@@ -15,9 +15,11 @@
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
 use olpc_cjson::CanonicalFormatter;
+use pkcs8::der::Decode;
 use serde::{Deserialize, Serialize};
 use std::cmp::PartialEq;
 use std::convert::TryFrom;
+use x509_cert::Certificate;
 
 use crate::crypto::{CosignVerificationKey, Signature};
 use crate::errors::{Result, SigstoreError};
@@ -56,11 +58,12 @@ impl SignedArtifactBundle {
     /// SignedArtifactBundle.
     pub fn verify_blob(&self, blob: &[u8]) -> Result<()> {
         let cert = BASE64_STD_ENGINE.decode(&self.cert)?;
-        let (_, pem) = x509_parser::pem::parse_x509_pem(&cert)?;
-        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
-        let subject_public_key = cert.public_key();
-        let ver_key =
-            CosignVerificationKey::try_from(subject_public_key).expect("conversion failed");
+        let pem = pem::parse(cert)?;
+        let cert = Certificate::from_der(&pem.contents).map_err(|e| {
+            SigstoreError::PKCS8SpkiError(format!("parse der into cert failed: {e}"))
+        })?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
+        let ver_key = CosignVerificationKey::try_from(&spki).expect("conversion failed");
         let signature = Signature::Base64Encoded(self.base64_signature.as_bytes());
         ver_key.verify_signature(signature, blob)?;
         Ok(())

--- a/src/cosign/constants.rs
+++ b/src/cosign/constants.rs
@@ -13,17 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use x509_parser::der_parser::{oid, oid::Oid};
+use const_oid::ObjectIdentifier;
 
-pub(crate) const SIGSTORE_ISSUER_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .1);
-pub(crate) const SIGSTORE_GITHUB_WORKFLOW_TRIGGER_OID: Oid<'static> =
-    oid!(1.3.6 .1 .4 .1 .57264 .1 .2);
-pub(crate) const SIGSTORE_GITHUB_WORKFLOW_SHA_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .3);
-pub(crate) const SIGSTORE_GITHUB_WORKFLOW_NAME_OID: Oid<'static> =
-    oid!(1.3.6 .1 .4 .1 .57264 .1 .4);
-pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REPOSITORY_OID: Oid<'static> =
-    oid!(1.3.6 .1 .4 .1 .57264 .1 .5);
-pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REF_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .57264 .1 .6);
+pub(crate) const SIGSTORE_ISSUER_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.1");
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_TRIGGER_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.2");
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_SHA_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.3");
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_NAME_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.4");
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REPOSITORY_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.5");
+pub(crate) const SIGSTORE_GITHUB_WORKFLOW_REF_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.6");
+/// OID of Ed25519, which is not included in the RustCrypto repo yet.
+pub(crate) const ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
 pub(crate) const SIGSTORE_OCI_MEDIA_TYPE: &str = "application/vnd.dev.cosign.simplesigning.v1+json";
 pub(crate) const SIGSTORE_SIGNATURE_ANNOTATION: &str = "dev.cosignproject.cosign/signature";

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -52,7 +52,7 @@ impl CertificatePool {
             let pc = match c.encoding {
                 crate::registry::CertificateEncoding::Pem => {
                     let pem_str = String::from_utf8(c.data.clone()).map_err(|_| {
-                        SigstoreError::UnexpectedError("certificate is not PEM encoded".to_string())
+                        SigstoreError::X509Error("certificate is not PEM encoded".to_string())
                     })?;
                     picky::x509::Cert::from_pem_str(&pem_str)
                 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -197,7 +197,7 @@ pub(crate) mod tests {
     use openssl::ec::{EcGroup, EcKey};
     use openssl::hash::MessageDigest;
     use openssl::nid::Nid;
-    use openssl::pkey;
+    use openssl::pkey::{self, Id, PKey};
     use openssl::x509::extension::{
         AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage,
         SubjectAlternativeName, SubjectKeyIdentifier,
@@ -278,6 +278,18 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
 
         let public_key = pkey::PKey::from_ec_key(ec_pub_key).expect("Cannot create pkey");
         let private_key = pkey::PKey::from_ec_key(ec_private_key).expect("Cannot create pkey");
+
+        (private_key, public_key)
+    }
+
+    pub(crate) fn generate_ed25519_keypair() -> (pkey::PKey<pkey::Private>, pkey::PKey<pkey::Public>)
+    {
+        let private_key = PKey::generate_ed25519().expect("Cannot create private key");
+        let public_key = private_key
+            .raw_public_key()
+            .expect("Cannot export public key");
+        let public_key = PKey::public_key_from_raw_bytes(&public_key, Id::ED25519)
+            .expect("Cannot create ec pub key");
 
         (private_key, public_key)
     }

--- a/src/crypto/signing_key/ed25519.rs
+++ b/src/crypto/signing_key/ed25519.rs
@@ -65,7 +65,6 @@ use std::convert::TryFrom;
 use ed25519::KeypairBytes;
 use ed25519_dalek::{Signer as _, SigningKey};
 use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
-use x509_parser::nom::AsBytes;
 
 use crate::{
     crypto::{verification_key::CosignVerificationKey, SigningScheme},
@@ -100,7 +99,7 @@ impl Ed25519Keys {
     /// Create a new `Ed25519Keys` Object from given `Ed25519Keys` Object.
     pub fn from_ed25519key(key: &Ed25519Keys) -> Result<Self> {
         let priv_key = key.private_key_to_der()?;
-        Ed25519Keys::from_der(priv_key.as_bytes())
+        Ed25519Keys::from_der(&priv_key[..])
     }
 
     /// Builds a `Ed25519Keys` from encrypted pkcs8 PEM-encoded private key.

--- a/src/crypto/signing_key/rsa/mod.rs
+++ b/src/crypto/signing_key/rsa/mod.rs
@@ -50,9 +50,11 @@
 //! assert!(verification_key.verify_signature(Signature::Raw(&signature_data),message).is_ok());
 //! ```
 
-use ::rsa::{pkcs1v15::SigningKey, pss::BlindedSigningKey};
-use ecdsa::SignatureEncoding;
-use signature::{Keypair, RandomizedSigner};
+use ::rsa::{
+    pkcs1v15::SigningKey,
+    pss::BlindedSigningKey,
+    signature::{Keypair, RandomizedSigner, SignatureEncoding},
+};
 
 use self::keypair::RSAKeys;
 
@@ -193,7 +195,7 @@ impl Signer for RSASigner {
             self,
             signer,
             _key,
-            signer.try_sign_with_rng(&mut rng, msg)?.to_vec()
+            signer.sign_with_rng(&mut rng, msg).to_vec()
         ))
     }
 

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -14,19 +14,19 @@
 // limitations under the License.
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
-use pkcs8::DecodePublicKey;
+use const_oid::db::rfc5912::{ID_EC_PUBLIC_KEY, RSA_ENCRYPTION};
+use pkcs8::{DecodePublicKey, SubjectPublicKeyInfo};
 use rsa::{pkcs1v15, pss};
 use sha2::{Digest, Sha256, Sha384};
 use signature::{DigestVerifier, Verifier};
 use std::convert::TryFrom;
-use x509_parser::x509::SubjectPublicKeyInfo;
 
 use super::{
     signing_key::{KeyPair, SigStoreSigner},
     Signature, SigningScheme,
 };
 
-use crate::errors::*;
+use crate::{cosign::constants::ED25519, errors::*};
 
 /// A key that can be used to verify signatures.
 ///
@@ -66,31 +66,47 @@ impl<'a> TryFrom<&SubjectPublicKeyInfo<'a>> for CosignVerificationKey {
     type Error = SigstoreError;
 
     fn try_from(subject_pub_key_info: &SubjectPublicKeyInfo<'a>) -> Result<Self> {
-        use x509_parser::public_key::PublicKey;
-
-        let pubkey = subject_pub_key_info.parsed()?;
-        match pubkey {
-            PublicKey::EC(_) => match pubkey.key_size() {
-                256 => CosignVerificationKey::from_der(
-                    subject_pub_key_info.raw,
-                    &SigningScheme::ECDSA_P256_SHA256_ASN1,
-                ),
-                384 => CosignVerificationKey::from_der(
-                    subject_pub_key_info.raw,
-                    &SigningScheme::ECDSA_P384_SHA384_ASN1,
-                ),
+        let algorithm = subject_pub_key_info.algorithm.oid;
+        let public_key_der = subject_pub_key_info.subject_public_key;
+        match algorithm {
+            ID_EC_PUBLIC_KEY => match public_key_der.len() {
+                65 => Ok(CosignVerificationKey::ECDSA_P256_SHA256_ASN1(
+                    ecdsa::VerifyingKey::try_from(*subject_pub_key_info).map_err(|e| {
+                        SigstoreError::PKCS8SpkiError(format!(
+                            "Ecdsa-P256 from der bytes to public key failed: {e}"
+                        ))
+                    })?,
+                )),
+                97 => Ok(CosignVerificationKey::ECDSA_P384_SHA384_ASN1(
+                    ecdsa::VerifyingKey::try_from(*subject_pub_key_info).map_err(|e| {
+                        SigstoreError::PKCS8SpkiError(format!(
+                            "Ecdsa-P384 from der bytes to public key failed: {e}"
+                        ))
+                    })?,
+                )),
                 _ => Err(SigstoreError::PublicKeyUnsupportedAlgorithmError(format!(
                     "EC with size {} is not supported",
-                    pubkey.key_size()
+                    // asn.1 encode caused different length
+                    (public_key_der.len() - 1) * 4
                 ))),
             },
-            PublicKey::RSA(_) => CosignVerificationKey::from_der(
-                subject_pub_key_info.raw,
-                &SigningScheme::RSA_PKCS1_SHA256(pubkey.key_size()),
-            ),
+            RSA_ENCRYPTION => {
+                let pubkey = rsa::RsaPublicKey::try_from(*subject_pub_key_info).map_err(|e| {
+                    SigstoreError::PKCS8SpkiError(format!(
+                        "RSA from der bytes to public key failed: {e}"
+                    ))
+                })?;
+                Ok(CosignVerificationKey::RSA_PKCS1_SHA256(
+                    pkcs1v15::VerifyingKey::<sha2::Sha256>::from(pubkey),
+                ))
+            }
+            //
+            ED25519 => Ok(CosignVerificationKey::ED25519(
+                ed25519_dalek::VerifyingKey::try_from(*subject_pub_key_info)?,
+            )),
             _ => Err(SigstoreError::PublicKeyUnsupportedAlgorithmError(format!(
                 "Key with algorithm OID {} is not supported",
-                subject_pub_key_info.algorithm.oid()
+                algorithm
             ))),
         }
     }
@@ -309,6 +325,9 @@ impl CosignVerificationKey {
 
 #[cfg(test)]
 mod tests {
+    use der::Decode;
+    use x509_cert::Certificate;
+
     use super::*;
     use crate::crypto::tests::*;
 
@@ -423,12 +442,12 @@ DwIDAQAB
 
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
-        let (_, pem) = x509_parser::pem::parse_x509_pem(&issued_cert_pem)?;
-        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
-        let subject_public_key = cert.public_key();
+        let pem = pem::parse(issued_cert_pem)?;
+        let cert = Certificate::from_der(&pem.contents)?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
-            CosignVerificationKey::try_from(subject_public_key).expect("conversion failed");
+            CosignVerificationKey::try_from(&spki).expect("conversion failed");
 
         assert!(matches!(
             cosign_verification_key,
@@ -450,12 +469,12 @@ DwIDAQAB
 
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
-        let (_, pem) = x509_parser::pem::parse_x509_pem(&issued_cert_pem)?;
-        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
-        let subject_public_key = cert.public_key();
+        let pem = pem::parse(issued_cert_pem)?;
+        let cert = Certificate::from_der(&pem.contents)?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
-            CosignVerificationKey::try_from(subject_public_key).expect("conversion failed");
+            CosignVerificationKey::try_from(&spki).expect("conversion failed");
 
         assert!(matches!(
             cosign_verification_key,
@@ -477,16 +496,43 @@ DwIDAQAB
 
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
-        let (_, pem) = x509_parser::pem::parse_x509_pem(&issued_cert_pem)?;
-        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
-        let subject_public_key = cert.public_key();
+        let pem = pem::parse(issued_cert_pem)?;
+        let cert = Certificate::from_der(&pem.contents)?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
-            CosignVerificationKey::try_from(subject_public_key).expect("conversion failed");
+            CosignVerificationKey::try_from(&spki).expect("conversion failed");
 
         assert!(matches!(
             cosign_verification_key,
             CosignVerificationKey::RSA_PKCS1_SHA256(_)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn convert_ed25519_subject_public_key_to_cosign_verification_key() -> anyhow::Result<()> {
+        let (private_key, public_key) = generate_ed25519_keypair();
+        let issued_cert_generation_options = CertGenerationOptions {
+            private_key,
+            public_key,
+            ..Default::default()
+        };
+
+        let ca_data = generate_certificate(None, CertGenerationOptions::default())?;
+
+        let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
+        let issued_cert_pem = issued_cert.cert.to_pem()?;
+        let pem = pem::parse(issued_cert_pem)?;
+        let cert = Certificate::from_der(&pem.contents)?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
+
+        let cosign_verification_key =
+            CosignVerificationKey::try_from(&spki).expect("conversion failed");
+
+        assert!(matches!(
+            cosign_verification_key,
+            CosignVerificationKey::ED25519(_)
         ));
         Ok(())
     }
@@ -505,11 +551,11 @@ DwIDAQAB
 
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
-        let (_, pem) = x509_parser::pem::parse_x509_pem(&issued_cert_pem)?;
-        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
-        let subject_public_key = cert.public_key();
+        let pem = pem::parse(issued_cert_pem)?;
+        let cert = Certificate::from_der(&pem.contents)?;
+        let spki = cert.tbs_certificate.subject_public_key_info;
 
-        let err = CosignVerificationKey::try_from(subject_public_key);
+        let err = CosignVerificationKey::try_from(&spki);
         assert!(matches!(
             err,
             Err(SigstoreError::PublicKeyUnsupportedAlgorithmError(_))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,17 +55,11 @@ pub enum SigstoreError {
     #[error("unmatched key type {key_typ} and signing scheme {scheme}")]
     UnmatchedKeyAndSigningScheme { key_typ: String, scheme: String },
 
-    #[error(transparent)]
-    PEMParseError(#[from] x509_parser::nom::Err<x509_parser::error::PEMError>),
+    #[error("x509 error: {0}")]
+    X509Error(String),
 
     #[error(transparent)]
     FromPEMError(#[from] pem::PemError),
-
-    #[error(transparent)]
-    X509ParseError(#[from] x509_parser::nom::Err<x509_parser::error::X509Error>),
-
-    #[error(transparent)]
-    X509Error(#[from] x509_parser::error::X509Error),
 
     #[error(transparent)]
     CertError(#[from] picky::x509::certificate::CertError),

--- a/src/fulcio/mod.rs
+++ b/src/fulcio/mod.rs
@@ -172,7 +172,7 @@ impl FulcioClient {
             signed_email_address: Some(signature),
         };
 
-        let csr: Body = csr.try_into()?;
+        let csr = TryInto::<Body>::try_into(csr)?;
 
         let client = reqwest::Client::new();
         let response = client


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Replace `x509-parser` with `x509-cert`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- `x509-cert` is from RustCrypto, and the replaced `x509-parser` depends on `ring`. This PR will help to get rid of `ring`.
- Add a test that converts a public key cert of ed25519 into a `CosignVerificationKey`