### PR TITLE
Remove lines about timestamp in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,6 @@
 //!- get_log_info
 //!- get_log_proof
 //!- get_public_key
-//!- get_timestamp_cert_chain
-//!- get_timestamp_response
 //!- search_index
 //!- search_log_query
 //!


### PR DESCRIPTION

[src/lib.rs]
- Remove `get_timestamp_cert_chain` and `get_timestamp_response` functions


#### Summary
- Remove functions related to timestamping from `src/lib.rs`
- Fixes https://github.com/sigstore/sigstore-rs/issues/107


#### Release Note
NONE

#### Documentation
NONE