### PR TITLE
Introduce Newtype `OciReference` into API for OCI image references.

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -21,7 +21,7 @@ use sigstore::cosign::verification_constraint::{
 use sigstore::cosign::{CosignCapabilities, SignatureLayer};
 use sigstore::crypto::SigningScheme;
 use sigstore::errors::SigstoreVerifyConstraintsError;
-use sigstore::registry::{ClientConfig, ClientProtocol};
+use sigstore::registry::{ClientConfig, ClientProtocol, OciReference};
 use sigstore::tuf::SigstoreRepository;
 use std::boxed::Box;
 use std::convert::TryFrom;
@@ -101,7 +101,7 @@ struct Cli {
     loops: u32,
 
     /// Name of the image to verify
-    image: String,
+    image: OciReference,
 
     /// Whether the registry uses HTTP
     #[clap(long)]
@@ -227,7 +227,7 @@ async fn run_app(
         }
     }
 
-    let image: &str = cli.image.as_str();
+    let image = &cli.image;
 
     let (cosign_signature_image, source_image_digest) = client.triangulate(image, auth).await?;
 

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::ops::Add;
 
 use async_trait::async_trait;
 use oci_distribution::manifest::OCI_IMAGE_MEDIA_TYPE;
@@ -23,7 +24,7 @@ use super::constants::{SIGSTORE_OCI_MEDIA_TYPE, SIGSTORE_SIGNATURE_ANNOTATION};
 use super::{CosignCapabilities, SignatureLayer};
 use crate::cosign::signature_layers::build_signature_layers;
 use crate::crypto::CosignVerificationKey;
-use crate::registry::{Auth, PushResponse};
+use crate::registry::{Auth, OciReference, PushResponse};
 use crate::{
     crypto::certificate_pool::CertificatePool,
     errors::{Result, SigstoreError},
@@ -44,30 +45,21 @@ pub struct Client {
 
 #[async_trait(?Send)]
 impl CosignCapabilities for Client {
-    async fn triangulate(&mut self, image: &str, auth: &Auth) -> Result<(String, String)> {
-        let image_reference: oci_distribution::Reference =
-            image
-                .parse()
-                .map_err(|_| SigstoreError::OciReferenceNotValidError {
-                    reference: image.to_string(),
-                })?;
-
+    async fn triangulate(
+        &mut self,
+        image: &OciReference,
+        auth: &Auth,
+    ) -> Result<(OciReference, String)> {
         let manifest_digest = self
             .registry_client
-            .fetch_manifest_digest(&image_reference, &auth.into())
+            .fetch_manifest_digest(&image.oci_reference, &auth.into())
             .await?;
 
-        let sign = format!(
-            "{}/{}:{}.sig",
-            image_reference.registry(),
-            image_reference.repository(),
-            manifest_digest.replace(':', "-")
+        let reference = OciReference::with_tag(
+            image.registry().to_string(),
+            image.repository().to_string(),
+            manifest_digest.replace(':', "-").add(".sig"),
         );
-        let reference = sign
-            .parse()
-            .map_err(|_| SigstoreError::OciReferenceNotValidError {
-                reference: image.to_string(),
-            })?;
 
         Ok((reference, manifest_digest))
     }
@@ -76,7 +68,7 @@ impl CosignCapabilities for Client {
         &mut self,
         auth: &Auth,
         source_image_digest: &str,
-        cosign_image: &str,
+        cosign_image: &OciReference,
     ) -> Result<Vec<SignatureLayer>> {
         let (manifest, layers) = self.fetch_manifest_and_layers(auth, cosign_image).await?;
         let image_manifest = match manifest {
@@ -105,16 +97,9 @@ impl CosignCapabilities for Client {
         &mut self,
         annotations: Option<HashMap<String, String>>,
         auth: &Auth,
-        target_reference: &str,
+        target_reference: &OciReference,
         signature_layers: Vec<SignatureLayer>,
     ) -> Result<PushResponse> {
-        let image_reference: oci_distribution::Reference =
-            target_reference
-                .parse()
-                .map_err(|_| SigstoreError::OciReferenceNotValidError {
-                    reference: target_reference.to_string(),
-                })?;
-
         let layers: Vec<oci_distribution::client::ImageLayer> = signature_layers
             .iter()
             .filter_map(|sl| {
@@ -143,7 +128,7 @@ impl CosignCapabilities for Client {
         manifest.media_type = Some(OCI_IMAGE_MEDIA_TYPE.to_string());
         self.registry_client
             .push(
-                &image_reference,
+                &target_reference.oci_reference,
                 &layers[..],
                 config,
                 &auth.into(),
@@ -159,28 +144,21 @@ impl Client {
     async fn fetch_manifest_and_layers(
         &mut self,
         auth: &Auth,
-        cosign_image: &str,
+        cosign_image: &OciReference,
     ) -> Result<(
         oci_distribution::manifest::OciManifest,
         Vec<oci_distribution::client::ImageLayer>,
     )> {
-        let cosign_image_reference: oci_distribution::Reference =
-            cosign_image
-                .parse()
-                .map_err(|_| SigstoreError::OciReferenceNotValidError {
-                    reference: cosign_image.to_string(),
-                })?;
-
         let oci_auth: oci_distribution::secrets::RegistryAuth = auth.into();
 
         let (manifest, _) = self
             .registry_client
-            .pull_manifest(&cosign_image_reference, &oci_auth)
+            .pull_manifest(&cosign_image.oci_reference, &oci_auth)
             .await?;
         let image_data = self
             .registry_client
             .pull(
-                &cosign_image_reference,
+                &cosign_image.oci_reference,
                 &oci_auth,
                 vec![SIGSTORE_OCI_MEDIA_TYPE],
             )
@@ -212,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn triangulate_sigstore_object() {
-        let image = "docker.io/busybox:latest";
+        let image = "docker.io/busybox:latest".parse().unwrap();
         let image_digest =
             String::from("sha256:f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b");
         let expected_image = "docker.io/library/busybox:sha256-f3cfc9d0dbf931d3db4685ec659b7ac68e2a578219da4aae65427886e649b06b.sig".parse().unwrap();
@@ -225,7 +203,7 @@ mod tests {
         let mut cosign_client = build_test_client(mock_client);
 
         let reference = cosign_client
-            .triangulate(image, &crate::registry::Auth::Anonymous)
+            .triangulate(&image, &crate::registry::Auth::Anonymous)
             .await;
 
         assert!(reference.is_ok());

--- a/src/cosign/payload/simple_signing.rs
+++ b/src/cosign/payload/simple_signing.rs
@@ -17,6 +17,8 @@
 //! the Container signature format described
 //! [here](https://github.com/containers/image/blob/a5061e5a5f00333ea3a92e7103effd11c6e2f51d/docs/containers-signature.5.md#json-data-format).
 
+use crate::registry::OciReference;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fmt};
@@ -47,7 +49,7 @@ impl fmt::Display for SimpleSigning {
 impl SimpleSigning {
     /// Create a new simple signing payload due to the given image reference
     /// and manifest_digest
-    pub fn new(image_ref: &str, manifest_digest: &str) -> Self {
+    pub fn new(image_ref: &OciReference, manifest_digest: &str) -> Self {
         Self {
             critical: Critical {
                 type_name: CRITICAL_TYPE_NAME.to_string(),

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -33,6 +33,7 @@ use super::constants::{
     SIGSTORE_OCI_MEDIA_TYPE, SIGSTORE_SIGNATURE_ANNOTATION,
 };
 use crate::crypto::certificate_pool::CertificatePool;
+use crate::registry::oci_reference::OciReference;
 use crate::{
     cosign::simple_signing::SimpleSigning,
     crypto::{self, CosignVerificationKey, Signature},
@@ -192,7 +193,9 @@ impl SignatureLayer {
     /// use sigstore::crypto::SigningScheme;
     ///
     /// async fn func() {
-    ///     let mut signature_layer = SignatureLayer::new_unsigned("example/test", "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").expect("create SignatureLayer failed");
+    ///     let mut signature_layer = SignatureLayer::new_unsigned(
+    ///         &"example/test".parse().unwrap(),
+    ///         "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").expect("create SignatureLayer failed");
     ///     // Now the SignatureLayer does not have a signature, we need
     ///     // to generate one
     ///     let signer = SigningScheme::ECDSA_P256_SHA256_ASN1.create_signer().expect("create signer failed");
@@ -205,7 +208,7 @@ impl SignatureLayer {
     /// }
     ///
     /// ```
-    pub fn new_unsigned(image_ref: &str, manifest_digest: &str) -> Result<Self> {
+    pub fn new_unsigned(image_ref: &OciReference, manifest_digest: &str) -> Result<Self> {
         let simple_signing = SimpleSigning::new(image_ref, manifest_digest);
 
         let payload = serde_json::to_vec(&simple_signing)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@
 //!   let mut client = sigstore::cosign::ClientBuilder::default()
 //!     .build()
 //!     .expect("Unexpected failure while building Client");
-//!   let image = "registry-testing.svc.lan/kubewarden/disallow-service-nodeport:v0.1.0";
+//!   let image = "registry-testing.svc.lan/kubewarden/disallow-service-nodeport:v0.1.0".parse().unwrap();
 //!   let (cosign_signature_image, source_image_digest) = client.triangulate(
-//!     image,
+//!     &image,
 //!     auth
 //!   ).await.expect("Unexpected failure while using triangulate");
 //! }
@@ -95,7 +95,8 @@
 //!     .expect("Unexpected failure while building Client");
 //!
 //!   // Obtained via `triangulate`
-//!   let cosign_image = "registry-testing.svc.lan/kubewarden/disallow-service-nodeport:sha256-5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e.sig";
+//!   let cosign_image = "registry-testing.svc.lan/kubewarden/disallow-service-nodeport:sha256-5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e.sig"
+//!     .parse().unwrap();
 //!   // Obtained via `triangulate`
 //!   let source_image_digest = "sha256-5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e";
 //!
@@ -103,7 +104,7 @@
 //!   let signature_layers = client.trusted_signature_layers(
 //!     auth,
 //!     source_image_digest,
-//!     cosign_image,
+//!     &cosign_image,
 //!   ).await.expect("Could not obtain signature layers");
 //!
 //!   // Define verification constraints

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -21,6 +21,11 @@ pub(crate) mod oci_client;
 #[cfg(feature = "cosign")]
 pub(crate) use oci_client::*;
 
+#[cfg(feature = "cosign")]
+pub mod oci_reference;
+#[cfg(feature = "cosign")]
+pub use oci_reference::OciReference;
+
 #[cfg(all(feature = "cosign", feature = "cached-client"))]
 pub(crate) mod oci_caching_client;
 #[cfg(all(feature = "cosign", feature = "cached-client"))]

--- a/src/registry/oci_reference.rs
+++ b/src/registry/oci_reference.rs
@@ -1,0 +1,91 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::SigstoreError;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+/// Reference provides a general type to represent any way of referencing images within an OCI registry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OciReference {
+    pub(crate) oci_reference: oci_distribution::Reference,
+}
+
+impl FromStr for OciReference {
+    type Err = SigstoreError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<oci_distribution::Reference>()
+            .map_err(|_| SigstoreError::OciReferenceNotValidError {
+                reference: s.to_string(),
+            })
+            .map(|oci_reference| OciReference { oci_reference })
+    }
+}
+
+impl OciReference {
+    /// Create a Reference with a registry, repository and tag.
+    pub fn with_tag(registry: String, repository: String, tag: String) -> Self {
+        OciReference {
+            oci_reference: oci_distribution::Reference::with_tag(registry, repository, tag),
+        }
+    }
+
+    /// Create a Reference with a registry, repository and digest.
+    pub fn with_digest(registry: String, repository: String, digest: String) -> Self {
+        OciReference {
+            oci_reference: oci_distribution::Reference::with_digest(registry, repository, digest),
+        }
+    }
+
+    /// Resolve the registry address of a given Reference.
+    ///
+    /// Some registries, such as docker.io, uses a different address for the actual
+    /// registry. This function implements such redirection.
+    pub fn resolve_registry(&self) -> &str {
+        self.oci_reference.resolve_registry()
+    }
+
+    /// registry returns the name of the registry.
+    pub fn registry(&self) -> &str {
+        self.oci_reference.registry()
+    }
+
+    /// repository returns the name of the repository
+    pub fn repository(&self) -> &str {
+        self.oci_reference.repository()
+    }
+
+    /// digest returns the object's digest, if present.
+    pub fn digest(&self) -> Option<&str> {
+        self.oci_reference.digest()
+    }
+
+    /// tag returns the object's tag, if present.
+    pub fn tag(&self) -> Option<&str> {
+        self.oci_reference.tag()
+    }
+
+    /// whole returns the whole reference.
+    pub fn whole(&self) -> String {
+        self.oci_reference.whole()
+    }
+}
+
+impl Display for OciReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.oci_reference.fmt(f)
+    }
+}

--- a/src/registry/oci_reference.rs
+++ b/src/registry/oci_reference.rs
@@ -17,7 +17,7 @@ use crate::errors::SigstoreError;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-/// Reference provides a general type to represent any way of referencing images within an OCI registry.
+/// `OciReference` provides a general type to represent any way of referencing images within an OCI registry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OciReference {
     pub(crate) oci_reference: oci_distribution::Reference,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This introduces a Newtype `OciReference` to the public API.

There are two motivations behind this change:
- improve the API to prevent errors such as #214 through a more descriptive type.
- The Newtype is a wrapper around the internally used `oci_distribution::Reference` type in order to prevent leaking this into the public API.

See also: #214 and #215

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.
-->

- Added type `OciReference` in `sigstore::registry::oci_reference` to represent OCI references in other APIs.
- `CosignCapabilities` trait: changed signature of functions `triangulate()`, `fetch_manifest_and_layers()`  `push_signature()`, parameters related OCI image references now have type `&OciReference` instead of `&str`.
- `SimpleSigning::new()`: changed type of `image_ref` to `&OciReference` from `&str` .
- `SignatureLayer::new_unsigned()`: changed type of parameter `image_ref` to `&OciReference` from `&str`.
- Updated examples broken by API changes both in examples folder and in the documentation.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

This only affects the crate docs, which I updated to address the changes to my best abilities.

Users can address the breaking API changes by via using the functions associated with the `FromStr` trait.