### PR TITLE
fix: make LogEntry Body an enum

### DIFF
--- a/src/rekor/models/log_entry.rs
+++ b/src/rekor/models/log_entry.rs
@@ -1,5 +1,4 @@
 use crate::errors::SigstoreError;
-use crate::rekor::models::hashedrekord::Spec;
 use crate::rekor::TreeSize;
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
 
@@ -7,6 +6,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Error, Value};
 use std::collections::HashMap;
 use std::str::FromStr;
+
+use super::{
+    AlpineAllOf, HashedrekordAllOf, HelmAllOf, IntotoAllOf, JarAllOf, RekordAllOf, Rfc3161AllOf,
+    RpmAllOf, TufAllOf,
+};
 
 /// Stores the response returned by Rekor after making a new entry
 #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -39,14 +43,25 @@ impl FromStr for LogEntry {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Body {
-    #[serde(rename = "kind")]
-    pub kind: String,
-    #[serde(rename = "apiVersion")]
-    pub api_version: String,
-    #[serde(rename = "spec")]
-    pub spec: Spec,
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+#[allow(non_camel_case_types)]
+pub enum Body {
+    alpine(AlpineAllOf),
+    helm(HelmAllOf),
+    jar(JarAllOf),
+    rfc3161(Rfc3161AllOf),
+    rpm(RpmAllOf),
+    tuf(TufAllOf),
+    intoto(IntotoAllOf),
+    hashedrekord(HashedrekordAllOf),
+    rekord(RekordAllOf),
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Self::hashedrekord(Default::default())
+    }
 }
 
 fn decode_body(s: &str) -> Result<Body, SigstoreError> {


### PR DESCRIPTION

Closes: https://github.com/sigstore/sigstore-rs/issues/243

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This commit updates the LogEntry body field type to be an enum instead of a struct. This enum will contain a variant for the different types of rekords that can be stored in Rekor.

The motivation for this change is that currently only Hashedrekord::Spec are supported as that is the type spec field in the current Body struct. For further details please see the linked issue.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
TODO:

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE