### PR TITLE
Swap over to using CDN to fetch TUF metadata

### DIFF
--- a/src/tuf/constants.rs
+++ b/src/tuf/constants.rs
@@ -21,9 +21,9 @@ lazy_static! {
         Regex::new(r#"fulcio(_v\d+)?\.crt\.pem"#).expect("cannot compile regexp");
 }
 
-pub(crate) const SIGSTORE_METADATA_BASE: &str = "https://sigstore-tuf-root.storage.googleapis.com/";
+pub(crate) const SIGSTORE_METADATA_BASE: &str = "https://tuf-repo-cdn.sigstore.dev";
 pub(crate) const SIGSTORE_TARGET_BASE: &str =
-    "https://sigstore-tuf-root.storage.googleapis.com/targets";
+    "https://tuf-repo-cdn.sigstore.dev/targets";
 
 pub(crate) const SIGSTORE_REKOR_PUB_KEY_TARGET: &str = "rekor.pub";
 

--- a/src/tuf/constants.rs
+++ b/src/tuf/constants.rs
@@ -22,8 +22,7 @@ lazy_static! {
 }
 
 pub(crate) const SIGSTORE_METADATA_BASE: &str = "https://tuf-repo-cdn.sigstore.dev";
-pub(crate) const SIGSTORE_TARGET_BASE: &str =
-    "https://tuf-repo-cdn.sigstore.dev/targets";
+pub(crate) const SIGSTORE_TARGET_BASE: &str = "https://tuf-repo-cdn.sigstore.dev/targets";
 
 pub(crate) const SIGSTORE_REKOR_PUB_KEY_TARGET: &str = "rekor.pub";
 


### PR DESCRIPTION
The TUF root for the production instance of sigstore is now addressable via a CDN endpoint; this change uses the CDN instead of calling GCS directly via its HTTP endpoint

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
