### PR TITLE
upgrade 'der' to 0.7.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ cached = { version = "0.42.0", optional = true }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.23", feature = "clock" }
 const-oid = "0.9.1"
-der = "0.6.1"
+der = "0.7.5"
 digest = { version = "0.10.3", default-features = false }
 ecdsa = { version = "0.15", features = [ "pkcs8", "digest", "der" ] }
 ed25519 = { version = "=2.1", features = [ "alloc" ] }

--- a/examples/rekor/create_log_entry/main.rs
+++ b/examples/rekor/create_log_entry/main.rs
@@ -82,7 +82,7 @@ async fn main() {
     .arg(Arg::new("key_format")
              .long("key_format")
              .value_name("KEY_FORMAT")
-             .help("Accepted formats are : pgp / x509 / minsign / ssh / tuf"))  
+             .help("Accepted formats are : pgp / x509 / minsign / ssh / tuf"))
     .arg(Arg::new("signature")
              .long("signature")
              .value_name("SIGNATURE")

--- a/src/crypto/certificate.rs
+++ b/src/crypto/certificate.rs
@@ -126,7 +126,7 @@ mod tests {
     use crate::crypto::tests::*;
 
     use chrono::{Duration, Utc};
-    use der::Decode;
+    use x509_cert::der::Decode;
 
     #[test]
     fn verify_cert_key_usages_success() -> anyhow::Result<()> {

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -329,7 +329,7 @@ impl CosignVerificationKey {
 
 #[cfg(test)]
 mod tests {
-    use der::Decode;
+    use x509_cert::der::Decode;
     use x509_cert::Certificate;
 
     use super::*;


### PR DESCRIPTION
This change makes minor source tweaks to upgrade the `der` dependency to version `0.7.5`.  It replaces the dependabot PR https://github.com/sigstore/sigstore-rs/pull/256 for which the CI builds are failing.
