### PR TITLE
remove unused 'clock' feature for chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ async-trait = "0.1.52"
 base64 = "0.21.0"
 cached = { version = "0.42.0", optional = true }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.23", feature = "clock" }
+chrono = { version = "0.4.23" }
 const-oid = "0.9.1"
 der = "0.7.5"
 digest = { version = "0.10.3", default-features = false }


### PR DESCRIPTION
This very minor change avoid the warning when running `cargo test`:
```bash
$ cargo test --all
warning: unused manifest key: dependencies.chrono.feature
```
