### PR TITLE
Address RUSTSEC-2023-0037

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tough = { version = "0.13", features = [ "http" ], optional = true }
 tracing = "0.1.31"
 url = "2.2.2"
 x509-cert = { version = "0.1.1", features = [ "pem", "std" ] }
-xsalsa20poly1305 = "0.9.0"
+crypto_secretbox = "0.1.1"
 zeroize = "1.5.7"
 
 [dev-dependencies]

--- a/src/crypto/signing_key/kdf.rs
+++ b/src/crypto/signing_key/kdf.rs
@@ -20,9 +20,9 @@
 //! for golang version.
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
+use crypto_secretbox::aead::{AeadMut, KeyInit};
 use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use xsalsa20poly1305::aead::{AeadMut, KeyInit};
 
 use crate::errors::*;
 
@@ -157,10 +157,10 @@ impl SecretBoxCipher {
             ));
         }
         self.encrypted = true;
-        let nonce = xsalsa20poly1305::Nonce::from_slice(&self.nonce);
-        let key = xsalsa20poly1305::Key::from_slice(key);
+        let nonce = crypto_secretbox::Nonce::from_slice(&self.nonce);
+        let key = crypto_secretbox::Key::from_slice(key);
 
-        let mut cipher = xsalsa20poly1305::XSalsa20Poly1305::new(key);
+        let mut cipher = crypto_secretbox::XSalsa20Poly1305::new(key);
         cipher
             .encrypt(nonce, plaintext)
             .map_err(|e| SigstoreError::PrivateKeyEncryptError(e.to_string()))
@@ -168,10 +168,10 @@ impl SecretBoxCipher {
 
     /// Unseal the ciphertext using the key
     fn decrypt(&self, ciphertext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-        let nonce = xsalsa20poly1305::Nonce::from_slice(&self.nonce);
-        let key = xsalsa20poly1305::Key::from_slice(key);
+        let nonce = crypto_secretbox::Nonce::from_slice(&self.nonce);
+        let key = crypto_secretbox::Key::from_slice(key);
 
-        let mut cipher = xsalsa20poly1305::XSalsa20Poly1305::new(key);
+        let mut cipher = crypto_secretbox::XSalsa20Poly1305::new(key);
         cipher
             .decrypt(nonce, ciphertext)
             .map_err(|e| SigstoreError::PrivateKeyEncryptError(e.to_string()))


### PR DESCRIPTION
#### Summary
Address RUSTSEC-2023-0037 security advisory.
Change references of the unmaintained crate xsalsa20poly1305 to crypto_secretbox.
It should fix the failing `security_audit` check - https://github.com/sigstore/sigstore-rs/actions/runs/5014422162/jobs/8988653668.

https://rustsec.org/advisories/RUSTSEC-2023-0037.html


#### Release Note
(Bug fixes and fixes of previous known issues)
- replace xsalsa20poly1305 with crypto_secretbox to address RUSTSEC-2023-0037 security advisory

#### Documentation
- no changes
