### PR TITLE
update pkcs1 from 0.4.0 to 0.7.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tough = { version = "0.13", features = [ "http" ], optional = true }
 tracing = "0.1.31"
 url = "2.2.2"
 x509-cert = { version = "0.1.1", features = [ "pem", "std" ] }
-xsalsa20poly1305 = "0.9.0"
+crypto_secretbox = "0.1.1"
 zeroize = "1.5.7"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,13 +70,13 @@ p384 = "0.12"
 webbrowser = "0.8.4"
 pem = "1.0.2"
 picky = { version = "7.0.0-rc.5", default-features = false, features = [ "x509", "ec" ] }
-pkcs1 = "0.4.0"
+pkcs1 = { version = "0.7.5", features = [ "std" ] }
 pkcs8 = { version = "0.9.0", features = ["pem", "alloc", "pkcs5", "encryption"] }
 rand = { version = "0.8.5", features = [ "getrandom", "std" ] }
 getrandom = "0.2.8"
 regex = { version = "1.5.5", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"], optional = true}
-rsa = "0.8.0"
+rsa = "0.8.2"
 scrypt = "0.10.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/src/crypto/signing_key/kdf.rs
+++ b/src/crypto/signing_key/kdf.rs
@@ -20,9 +20,9 @@
 //! for golang version.
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
+use crypto_secretbox::aead::{AeadMut, KeyInit};
 use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use xsalsa20poly1305::aead::{AeadMut, KeyInit};
 
 use crate::errors::*;
 
@@ -157,10 +157,10 @@ impl SecretBoxCipher {
             ));
         }
         self.encrypted = true;
-        let nonce = xsalsa20poly1305::Nonce::from_slice(&self.nonce);
-        let key = xsalsa20poly1305::Key::from_slice(key);
+        let nonce = crypto_secretbox::Nonce::from_slice(&self.nonce);
+        let key = crypto_secretbox::Key::from_slice(key);
 
-        let mut cipher = xsalsa20poly1305::XSalsa20Poly1305::new(key);
+        let mut cipher = crypto_secretbox::XSalsa20Poly1305::new(key);
         cipher
             .encrypt(nonce, plaintext)
             .map_err(|e| SigstoreError::PrivateKeyEncryptError(e.to_string()))
@@ -168,10 +168,10 @@ impl SecretBoxCipher {
 
     /// Unseal the ciphertext using the key
     fn decrypt(&self, ciphertext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-        let nonce = xsalsa20poly1305::Nonce::from_slice(&self.nonce);
-        let key = xsalsa20poly1305::Key::from_slice(key);
+        let nonce = crypto_secretbox::Nonce::from_slice(&self.nonce);
+        let key = crypto_secretbox::Key::from_slice(key);
 
-        let mut cipher = xsalsa20poly1305::XSalsa20Poly1305::new(key);
+        let mut cipher = crypto_secretbox::XSalsa20Poly1305::new(key);
         cipher
             .decrypt(nonce, ciphertext)
             .map_err(|e| SigstoreError::PrivateKeyEncryptError(e.to_string()))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -207,6 +207,9 @@ pub enum SigstoreError {
     RSAError(#[from] rsa::errors::Error),
 
     #[error(transparent)]
+    RSAPKCS1Error(#[from] rsa::pkcs1::Error),
+
+    #[error(transparent)]
     PKCS1Error(#[from] pkcs1::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
Update the [pkcs1](https://crates.io/crates/pkcs1) dependency to the latest version, `0.7.5` - with minor necessary source code adjustments.

Currently PR is cumulative with #259 - can either merge this one to cover both small changes, or I can rebase it one #259 is merged.