### PR TITLE
use 2021 Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
 version = "0.6.0"
-edition = "2018"
+edition = "2021"
 authors = [
   "sigstore-rs developers",
 ]


### PR DESCRIPTION
since this crate is new and indicated as "experimental", suggesting to use the latest 2021 edition.