### PR TITLE
update scrypt to 0.11.0, adapt for API change (fix #231)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ getrandom = "0.2.8"
 regex = { version = "1.5.5", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"], optional = true}
 rsa = "0.8.2"
-scrypt = "0.10.0"
+scrypt = "0.11.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = { version = "0.10.6", features = ["oid"] }

--- a/src/crypto/signing_key/kdf.rs
+++ b/src/crypto/signing_key/kdf.rs
@@ -108,7 +108,12 @@ impl ScryptKDF {
     /// Derivate a new key from the given password
     fn key(&self, password: &[u8]) -> Result<Vec<u8>> {
         let log_n = (self.params.n as f64).log2() as u8;
-        let params = scrypt::Params::new(log_n, self.params.r, self.params.p)?;
+        let params = scrypt::Params::new(
+            log_n,
+            self.params.r,
+            self.params.p,
+            scrypt::Params::RECOMMENDED_LEN,
+        )?;
         let mut res = Vec::new();
         res.resize(BOX_KEY_SIZE, 0x00);
         scrypt::scrypt(password, &self.salt, &params, &mut res)?;


### PR DESCRIPTION
PR is a fixed version of #231 with the call to [scrypt::Params::new](https://docs.rs/scrypt/0.11.0/scrypt/struct.Params.html#method.new) modified for the crate's API change.