### PR TITLE
Update crypto deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,6 @@ cached = { version = "0.42.0", optional = true }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.23" }
 const-oid = "0.9.1"
-# TODO: consume via x509-cert?
-der = "0.7.5"
 digest = { version = "0.10.3", default-features = false }
 ecdsa = { version = "0.16.7", features = ["pkcs8", "digest", "der", "signing"] }
 ed25519 = { version = "2.2.1", features = ["alloc"] }
@@ -114,8 +112,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = { version = "0.10.6", features = ["oid"] }
 signature = { version = "2.0" }
-# TODO: consume via x509-cert?
-spki = { version = "0.7.2", features = ["pem", "std"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["rt"] }
 tough = { version = "0.13", features = ["http"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ openidconnect = { version = "2.3", default-features = false, features = [
 p256 = "0.13.2"
 p384 = "0.13"
 webbrowser = "0.8.4"
-pem = "1.0.2"
+pem = "2.0"
 picky = { version = "7.0.0-rc.5", default-features = false, features = [
   "x509",
   "ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,20 +73,21 @@ cached = { version = "0.42.0", optional = true }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.23" }
 const-oid = "0.9.1"
+# TODO: consume via x509-cert?
 der = "0.7.5"
 digest = { version = "0.10.3", default-features = false }
-ecdsa = { version = "0.15", features = ["pkcs8", "digest", "der"] }
+ecdsa = { version = "0.16.7", features = ["pkcs8", "digest", "der", "signing"] }
 ed25519 = { version = "2.2.1", features = ["alloc"] }
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["pkcs8", "rand_core"] }
-elliptic-curve = { version = "0.12.2", features = ["arithmetic", "pem"] }
+elliptic-curve = { version = "0.13.5", features = ["arithmetic", "pem"] }
 lazy_static = "1.4.0"
 oci-distribution = { version = "0.9", default-features = false, optional = true }
 olpc-cjson = "0.1"
 openidconnect = { version = "2.3", default-features = false, features = [
   "reqwest",
 ], optional = true }
-p256 = "0.12"
-p384 = "0.12"
+p256 = "0.13.2"
+p384 = "0.13"
 webbrowser = "0.8.4"
 pem = "1.0.2"
 picky = { version = "7.0.0-rc.5", default-features = false, features = [
@@ -94,7 +95,7 @@ picky = { version = "7.0.0-rc.5", default-features = false, features = [
   "ec",
 ] }
 pkcs1 = { version = "0.7.5", features = ["std"] }
-pkcs8 = { version = "0.9.0", features = [
+pkcs8 = { version = "0.10.2", features = [
   "pem",
   "alloc",
   "pkcs5",
@@ -107,19 +108,20 @@ reqwest = { version = "0.11", default-features = false, features = [
   "json",
   "multipart",
 ], optional = true }
-rsa = "0.8.2"
+rsa = "0.9.2"
 scrypt = "0.11.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = { version = "0.10.6", features = ["oid"] }
 signature = { version = "2.0" }
+# TODO: consume via x509-cert?
 spki = { version = "0.7.2", features = ["pem", "std"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["rt"] }
 tough = { version = "0.13", features = ["http"], optional = true }
 tracing = "0.1.31"
 url = "2.2.2"
-x509-cert = { version = "0.1.1", features = ["pem", "std"] }
+x509-cert = { version = "0.2.2", features = ["pem", "std"] }
 crypto_secretbox = "0.1.1"
 zeroize = "1.5.7"
 

--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -349,7 +349,7 @@ fn parse_cert_bundle(bundle_path: &str) -> Result<Vec<sigstore::registry::Certif
         .iter()
         .map(|pem| sigstore::registry::Certificate {
             encoding: sigstore::registry::CertificateEncoding::Der,
-            data: pem.contents.clone(),
+            data: pem.contents().to_vec(),
         })
         .collect())
 }

--- a/examples/fulcio/cert/main.rs
+++ b/examples/fulcio/cert/main.rs
@@ -21,7 +21,7 @@ async fn main() {
 
         let pems = pem::parse_many(cert.as_ref()).expect("parse pem failed");
         for pem in &pems {
-            let cert = Certificate::from_der(&pem.contents).expect("parse certificate from der");
+            let cert = Certificate::from_der(pem.contents()).expect("parse certificate from der");
 
             let (_, san) = cert
                 .tbs_certificate

--- a/examples/rekor/create_log_entry/main.rs
+++ b/examples/rekor/create_log_entry/main.rs
@@ -98,10 +98,8 @@ async fn main() {
 
     // The following default values will be used if the user does not input values using cli flags
     const HASH: &str = "c7ead87fa5c82d2b17feece1c2ee1bda8e94788f4b208de5057b3617a42b7413";
-    const URL: &str = "https://raw.githubusercontent.com/jyotsna-penumaka/rekor-rs/rekor-functionality/test_data/data";
     const PUBLIC_KEY: &str = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFeEhUTWRSQk80ZThCcGZ3cG5KMlozT2JMRlVrVQpaUVp6WGxtKzdyd1lZKzhSMUZpRWhmS0JZclZraGpHL2lCUjZac2s3Z01iYWZPOG9FM01lUEVvWU93PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==";
     const SIGNATURE: &str = "MEUCIHWACbBnw+YkJCy2tVQd5i7VH6HgkdVBdP7HRV1IEsDuAiEA19iJNvmkE6We7iZGjHsTkjXV8QhK9iXu0ArUxvJF1N8=";
-    const KEY_FORMAT: &str = "x509";
     const API_VERSION: &str = "0.0.1";
 
     let hash = Hash::new(

--- a/examples/rekor/search_log_query/main.rs
+++ b/examples/rekor/search_log_query/main.rs
@@ -41,10 +41,8 @@ async fn main() {
 
     // The following default values will be used if the user does not input values using cli flags
     const HASH: &str = "c7ead87fa5c82d2b17feece1c2ee1bda8e94788f4b208de5057b3617a42b7413";
-    const URL: &str = "https://raw.githubusercontent.com/jyotsna-penumaka/rekor-rs/rekor-functionality/test_data/data";
     const PUBLIC_KEY: &str = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFeEhUTWRSQk80ZThCcGZ3cG5KMlozT2JMRlVrVQpaUVp6WGxtKzdyd1lZKzhSMUZpRWhmS0JZclZraGpHL2lCUjZac2s3Z01iYWZPOG9FM01lUEVvWU93PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==";
     const SIGNATURE: &str = "MEUCIHWACbBnw+YkJCy2tVQd5i7VH6HgkdVBdP7HRV1IEsDuAiEA19iJNvmkE6We7iZGjHsTkjXV8QhK9iXu0ArUxvJF1N8=";
-    const KEY_FORMAT: &str = "x509";
     const API_VERSION: &str = "0.0.1";
     const ENTRY_UUIDS: &str = "1377da9d9dbad451a5a8acdd28add750815d34e8205f1b8a35a67b8a27dae9bf";
     const LOG_INDEXES: &str = "2922253";

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -161,7 +161,7 @@ pub trait CosignCapabilities {
     fn verify_blob(cert: &str, signature: &str, blob: &[u8]) -> Result<()> {
         let cert = BASE64_STD_ENGINE.decode(cert)?;
         let pem = pem::parse(cert)?;
-        let cert = Certificate::from_der(&pem.contents).map_err(|e| {
+        let cert = Certificate::from_der(pem.contents()).map_err(|e| {
             SigstoreError::PKCS8SpkiError(format!("parse der into cert failed: {e}"))
         })?;
         let spki = cert.tbs_certificate.subject_public_key_info;

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -429,16 +429,16 @@ impl CertificateSignature {
     /// Ensures the given certificate can be trusted, then extracts
     /// its details and returns them as a `CertificateSignature` object
     pub(crate) fn from_certificate(
-        cert_raw: &[u8],
+        cert_pem: &[u8],
         fulcio_cert_pool: &CertificatePool,
         trusted_bundle: &Bundle,
     ) -> Result<Self> {
-        let cert = Certificate::from_pem(&cert_raw)
+        let cert = Certificate::from_pem(cert_pem)
             .map_err(|e| SigstoreError::X509Error(format!("parse from pem: {e}")))?;
         let integrated_time = trusted_bundle.payload.integrated_time;
 
         // ensure the certificate has been issued by Fulcio
-        fulcio_cert_pool.verify_pem_cert(cert_raw)?;
+        fulcio_cert_pool.verify_pem_cert(cert_pem)?;
 
         crypto::certificate::is_trusted(&cert, integrated_time)?;
 

--- a/src/cosign/verification_constraint/certificate_verifier.rs
+++ b/src/cosign/verification_constraint/certificate_verifier.rs
@@ -35,7 +35,7 @@ impl CertificateVerifier {
         cert_chain: Option<&[crate::registry::Certificate]>,
     ) -> Result<Self> {
         let pem = pem::parse(cert_bytes)?;
-        Self::from_der(&pem.contents, require_rekor_bundle, cert_chain)
+        Self::from_der(pem.contents(), require_rekor_bundle, cert_chain)
     }
 
     /// Create a new instance of `CertificateVerifier` using the DER encoded

--- a/src/crypto/certificate.rs
+++ b/src/crypto/certificate.rs
@@ -135,7 +135,7 @@ mod tests {
         let issued_cert = generate_certificate(Some(&ca_data), CertGenerationOptions::default())?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
         assert!(verify_key_usages(&cert).is_ok());
 
         Ok(())
@@ -154,7 +154,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         let err = verify_key_usages(&cert).expect_err("Was supposed to return an error");
         let found = match err {
@@ -179,7 +179,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         let err = verify_key_usages(&cert).expect_err("Was supposed to return an error");
         let found = match err {
@@ -205,7 +205,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         let error = verify_has_san(&cert).expect_err("Didn't get an error");
         let found = match error {
@@ -224,7 +224,7 @@ mod tests {
         let issued_cert = generate_certificate(Some(&ca_data), CertGenerationOptions::default())?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         assert!(verify_validity(&cert).is_ok());
 
@@ -245,7 +245,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         let err = verify_validity(&cert).expect_err("Was expecting an error");
         let found = match err {
@@ -273,7 +273,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         assert!(verify_expiration(&cert, integrated_time.timestamp(),).is_ok());
 
@@ -296,7 +296,7 @@ mod tests {
         )?;
         let issued_cert_pem = issued_cert.cert.to_pem().unwrap();
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = x509_cert::Certificate::from_der(&pem.contents)?;
+        let cert = x509_cert::Certificate::from_der(pem.contents())?;
 
         let err = verify_expiration(&cert, integrated_time.timestamp())
             .expect_err("Was expecting an error");

--- a/src/crypto/signing_key/ecdsa/ec.rs
+++ b/src/crypto/signing_key/ecdsa/ec.rs
@@ -73,7 +73,10 @@ use digest::{
     },
     Digest, FixedOutput, FixedOutputReset,
 };
-use ecdsa::{hazmat::SignPrimitive, PrimeCurve, SignatureSize, SigningKey};
+use ecdsa::{
+    hazmat::{DigestPrimitive, SignPrimitive},
+    PrimeCurve, SignatureSize, SigningKey,
+};
 use elliptic_curve::{
     bigint::ArrayEncoding,
     generic_array::ArrayLength,
@@ -81,10 +84,9 @@ use elliptic_curve::{
     sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
     subtle::CtOption,
     zeroize::Zeroizing,
-    AffineArithmetic, AffinePoint, Curve, FieldSize, ProjectiveArithmetic, PublicKey, Scalar,
-    SecretKey,
+    AffinePoint, Curve, CurveArithmetic, FieldBytesSize, PublicKey, Scalar, SecretKey,
 };
-use pkcs8::{der::Encode, AssociatedOid, DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
+use pkcs8::{AssociatedOid, DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
 use signature::DigestSigner;
 
 use crate::{
@@ -110,7 +112,7 @@ use super::ECDSAKeys;
 #[derive(Clone, Debug)]
 pub struct EcdsaKeys<C>
 where
-    C: Curve + ProjectiveArithmetic + pkcs8::AssociatedOid,
+    C: Curve + CurveArithmetic + pkcs8::AssociatedOid,
 {
     ec_seckey: SecretKey<C>,
     public_key: PublicKey<C>,
@@ -118,9 +120,9 @@ where
 
 impl<C> EcdsaKeys<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic + PrimeCurve,
+    C: Curve + AssociatedOid + CurveArithmetic + PrimeCurve,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Create a new `EcdsaKeys` Object, the generic parameter indicates
     /// the elliptic curve. Please refer to
@@ -128,7 +130,7 @@ where
     /// The secret key (private key) will be randomly
     /// generated.
     pub fn new() -> Result<Self> {
-        let ec_seckey: SecretKey<C> = SecretKey::random(rand::rngs::OsRng);
+        let ec_seckey: SecretKey<C> = SecretKey::random(&mut rand::rngs::OsRng);
 
         let public_key = ec_seckey.public_key();
         Ok(EcdsaKeys {
@@ -207,9 +209,9 @@ where
 
 impl<C> KeyPair for EcdsaKeys<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic + PrimeCurve,
+    C: Curve + AssociatedOid + CurveArithmetic + PrimeCurve,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Return the public key in PEM-encoded SPKI format.
     fn public_key_to_pem(&self) -> Result<String> {
@@ -249,9 +251,7 @@ where
         let pem = match password.len() {
             0 => pem::Pem {
                 tag: PRIVATE_KEY_PEM_LABEL.to_string(),
-                contents: der
-                    .to_vec()
-                    .map_err(|e| SigstoreError::PKCS8DerError(e.to_string()))?,
+                contents: der.to_vec(),
             },
             _ => pem::Pem {
                 tag: SIGSTORE_PRIVATE_KEY_PEM_LABEL.to_string(),
@@ -285,11 +285,11 @@ where
 #[derive(Clone, Debug)]
 pub struct EcdsaSigner<C, D>
 where
-    C: PrimeCurve + ProjectiveArithmetic + AssociatedOid,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
-    C::UInt: for<'a> From<&'a Scalar<C>>,
+    C: PrimeCurve + CurveArithmetic + AssociatedOid,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
+    C::Uint: for<'a> From<&'a Scalar<C>>,
     SignatureSize<C>: ArrayLength<u8>,
-    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
+    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
 {
     signing_key: SigningKey<C>,
     ecdsa_keys: EcdsaKeys<C>,
@@ -298,13 +298,13 @@ where
 
 impl<C, D> EcdsaSigner<C, D>
 where
-    C: PrimeCurve + ProjectiveArithmetic + AssociatedOid,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
+    C: PrimeCurve + CurveArithmetic + AssociatedOid,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
-    C::UInt: for<'a> From<&'a Scalar<C>>,
+    FieldBytesSize<C>: ModulusSize,
+    C::Uint: for<'a> From<&'a Scalar<C>>,
     SignatureSize<C>: ArrayLength<u8>,
-    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
+    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
 {
     /// Create a new `EcdsaSigner` from the given `EcdsaKeys` and `SignatureDigestAlgorithm`
     pub fn from_ecdsa_keys(ecdsa_keys: &EcdsaKeys<C>) -> Result<Self> {
@@ -332,20 +332,21 @@ where
 
 impl<C, D> Signer for EcdsaSigner<C, D>
 where
-    C: PrimeCurve + ProjectiveArithmetic + AssociatedOid,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
+    C: PrimeCurve + CurveArithmetic + AssociatedOid + DigestPrimitive,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SigningKey<C>: ecdsa::signature::Signer<ecdsa::Signature<C>>,
-    C::UInt: for<'a> From<&'a Scalar<C>>,
-    <<<C as Curve>::UInt as ArrayEncoding>::ByteSize as Add>::Output:
+    C::Uint: for<'a> From<&'a Scalar<C>>,
+    <<C as Curve>::FieldBytesSize as Add>::Output:
         Add<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B1>>,
-    <<<<C as Curve>::UInt as ArrayEncoding>::ByteSize as Add>::Output as Add<
+    <<<C as Curve>::FieldBytesSize as Add>::Output as Add<
         UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B1>,
     >>::Output: ArrayLength<u8>,
     SignatureSize<C>: ArrayLength<u8>,
-    <<C as Curve>::UInt as ArrayEncoding>::ByteSize: ModulusSize,
-    <C as AffineArithmetic>::AffinePoint: ToEncodedPoint<C>,
-    <C as AffineArithmetic>::AffinePoint: FromEncodedPoint<C>,
-    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
+    <<C as Curve>::Uint as ArrayEncoding>::ByteSize: ModulusSize,
+    <C as Curve>::FieldBytesSize: ModulusSize,
+    <C as CurveArithmetic>::AffinePoint: ToEncodedPoint<C>,
+    <C as CurveArithmetic>::AffinePoint: FromEncodedPoint<C>,
+    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
 {
     /// Sign the given message, and generate a signature.
     /// The message will firstly be hashed with the given
@@ -356,9 +357,9 @@ where
     fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
         let mut hasher = D::new();
         digest::Digest::update(&mut hasher, msg);
-        let sig = self.signing_key.try_sign_digest(hasher)?.to_der();
+        let (sig, _recovery_id) = self.signing_key.try_sign_digest(hasher)?;
 
-        Ok(sig.as_bytes().to_vec())
+        Ok(sig.to_der().to_bytes().to_vec())
     }
 
     /// Return the ref to the keypair inside the signer

--- a/src/crypto/signing_key/rsa/keypair.rs
+++ b/src/crypto/signing_key/rsa/keypair.rs
@@ -183,19 +183,19 @@ impl RSAKeys {
             PaddingScheme::PKCS1v15 => match digest_algorithm {
                 DigestAlgorithm::Sha256 => {
                     SigStoreSigner::RSA_PKCS1_SHA256(RSASigner::RSA_PKCS1_SHA256(
-                        SigningKey::<sha2::Sha256>::new_with_prefix(private_key),
+                        SigningKey::<sha2::Sha256>::new(private_key),
                         self.clone(),
                     ))
                 }
                 DigestAlgorithm::Sha384 => {
                     SigStoreSigner::RSA_PKCS1_SHA384(RSASigner::RSA_PKCS1_SHA384(
-                        SigningKey::<sha2::Sha384>::new_with_prefix(private_key),
+                        SigningKey::<sha2::Sha384>::new(private_key),
                         self.clone(),
                     ))
                 }
                 DigestAlgorithm::Sha512 => {
                     SigStoreSigner::RSA_PKCS1_SHA512(RSASigner::RSA_PKCS1_SHA512(
-                        SigningKey::<sha2::Sha512>::new_with_prefix(private_key),
+                        SigningKey::<sha2::Sha512>::new(private_key),
                         self.clone(),
                     ))
                 }

--- a/src/crypto/signing_key/rsa/keypair.rs
+++ b/src/crypto/signing_key/rsa/keypair.rs
@@ -90,9 +90,9 @@ impl RSAKeys {
     /// [`SIGSTORE_PRIVATE_KEY_PEM_LABEL`].
     pub fn from_encrypted_pem(encrypted_pem: &[u8], password: &[u8]) -> Result<Self> {
         let key = pem::parse(encrypted_pem)?;
-        match &key.tag[..] {
+        match key.tag() {
             COSIGN_PRIVATE_KEY_PEM_LABEL | SIGSTORE_PRIVATE_KEY_PEM_LABEL => {
-                let der = kdf::decrypt(&key.contents, password)?;
+                let der = kdf::decrypt(key.contents(), password)?;
                 let pkcs8 = pkcs8::PrivateKeyInfo::try_from(&der[..]).map_err(|e| {
                     SigstoreError::PKCS8Error(format!("Read PrivateKeyInfo failed: {e}"))
                 })?;
@@ -234,14 +234,11 @@ impl KeyPair for RSAKeys {
     fn private_key_to_encrypted_pem(&self, password: &[u8]) -> Result<zeroize::Zeroizing<String>> {
         let der = self.private_key_to_der()?;
         let pem = match password.len() {
-            0 => pem::Pem {
-                tag: PRIVATE_KEY_PEM_LABEL.to_string(),
-                contents: der.to_vec(),
-            },
-            _ => pem::Pem {
-                tag: SIGSTORE_PRIVATE_KEY_PEM_LABEL.to_string(),
-                contents: kdf::encrypt(&der, password)?,
-            },
+            0 => pem::Pem::new(PRIVATE_KEY_PEM_LABEL, der.to_vec()),
+            _ => pem::Pem::new(
+                SIGSTORE_PRIVATE_KEY_PEM_LABEL,
+                kdf::encrypt(&der, password)?,
+            ),
         };
         let pem = pem::encode(&pem);
         Ok(zeroize::Zeroizing::new(pem))

--- a/src/crypto/signing_key/rsa/mod.rs
+++ b/src/crypto/signing_key/rsa/mod.rs
@@ -141,15 +141,15 @@ impl RSASigner {
             },
             PaddingScheme::PKCS1v15 => match digest_algorithm {
                 DigestAlgorithm::Sha256 => RSASigner::RSA_PKCS1_SHA256(
-                    SigningKey::<sha2::Sha256>::new_with_prefix(private_key),
+                    SigningKey::<sha2::Sha256>::new(private_key),
                     rsa_keys.clone(),
                 ),
                 DigestAlgorithm::Sha384 => RSASigner::RSA_PKCS1_SHA384(
-                    SigningKey::<sha2::Sha384>::new_with_prefix(private_key),
+                    SigningKey::<sha2::Sha384>::new(private_key),
                     rsa_keys.clone(),
                 ),
                 DigestAlgorithm::Sha512 => RSASigner::RSA_PKCS1_SHA512(
-                    SigningKey::<sha2::Sha512>::new_with_prefix(private_key),
+                    SigningKey::<sha2::Sha512>::new(private_key),
                     rsa_keys.clone(),
                 ),
             },

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -15,13 +15,12 @@
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STD_ENGINE, Engine as _};
 use const_oid::db::rfc5912::{ID_EC_PUBLIC_KEY, RSA_ENCRYPTION};
-use der::referenced::OwnedToRef;
 use ed25519::pkcs8::DecodePublicKey as ED25519DecodePublicKey;
 use rsa::{pkcs1v15, pss};
 use sha2::{Digest, Sha256, Sha384};
 use signature::{DigestVerifier, Verifier};
 use std::convert::TryFrom;
-use x509_cert::spki::SubjectPublicKeyInfoOwned;
+use x509_cert::{der::referenced::OwnedToRef, spki::SubjectPublicKeyInfoOwned};
 
 use super::{
     signing_key::{KeyPair, SigStoreSigner},

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -232,7 +232,7 @@ impl CosignVerificationKey {
     /// from the DER-encoded bytes.
     pub fn from_pem(pem_data: &[u8], signing_scheme: &SigningScheme) -> Result<Self> {
         let key_pem = pem::parse(pem_data)?;
-        Self::from_der(key_pem.contents.as_slice(), signing_scheme)
+        Self::from_der(key_pem.contents(), signing_scheme)
     }
 
     /// Builds a [`CosignVerificationKey`] from PEM-encoded public key data. This function will
@@ -243,7 +243,7 @@ impl CosignVerificationKey {
     /// * `Ed25519 public key`: `Ed25519`
     pub fn try_from_pem(pem_data: &[u8]) -> Result<Self> {
         let key_pem = pem::parse(pem_data)?;
-        Self::try_from_der(key_pem.contents.as_slice())
+        Self::try_from_der(key_pem.contents())
     }
 
     /// Builds a `CosignVerificationKey` from [`SigStoreSigner`]. The methods will derive
@@ -451,7 +451,7 @@ DwIDAQAB
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = Certificate::from_der(&pem.contents)?;
+        let cert = Certificate::from_der(pem.contents())?;
         let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
@@ -478,7 +478,7 @@ DwIDAQAB
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = Certificate::from_der(&pem.contents)?;
+        let cert = Certificate::from_der(pem.contents())?;
         let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
@@ -505,7 +505,7 @@ DwIDAQAB
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = Certificate::from_der(&pem.contents)?;
+        let cert = Certificate::from_der(pem.contents())?;
         let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
@@ -532,7 +532,7 @@ DwIDAQAB
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = Certificate::from_der(&pem.contents)?;
+        let cert = Certificate::from_der(pem.contents())?;
         let spki = cert.tbs_certificate.subject_public_key_info;
 
         let cosign_verification_key =
@@ -560,7 +560,7 @@ DwIDAQAB
         let issued_cert = generate_certificate(Some(&ca_data), issued_cert_generation_options)?;
         let issued_cert_pem = issued_cert.cert.to_pem()?;
         let pem = pem::parse(issued_cert_pem)?;
-        let cert = Certificate::from_der(&pem.contents)?;
+        let cert = Certificate::from_der(pem.contents())?;
         let spki = cert.tbs_certificate.subject_public_key_info;
 
         let err = CosignVerificationKey::try_from(&spki);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -207,9 +207,6 @@ pub enum SigstoreError {
     RSAError(#[from] rsa::errors::Error),
 
     #[error(transparent)]
-    RSAPKCS1Error(#[from] rsa::pkcs1::Error),
-
-    #[error(transparent)]
     PKCS1Error(#[from] pkcs1::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
Update to the latest version of a bunch of crypto libraries. These libraries, especially the ones that belong to RustCrypto, have to be updated at the same time.

There have been a lot of API changes and deprecation warnigns, which needed quite some adaptation of our codebase.

Moreover, remove `der` and `scrypt` deps.
These dependencies are also exported by the `x509-cert` crate. We're going to consume them via this crate to simply dependency management.
These two dependencies must move in sync with `x509-cert`, hence it makes a lot of sense to leverage the export provided by this crate.
