### PR TITLE
fix: ensure cosign client can be sent between threads

### DIFF
--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -43,7 +43,8 @@ pub struct Client {
     pub(crate) fulcio_cert_pool: Option<CertificatePool>,
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl CosignCapabilities for Client {
     async fn triangulate(
         &mut self,

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -71,7 +71,9 @@ use crate::registry::oci_reference::OciReference;
 pub use payload::simple_signing;
 
 pub mod constraint;
-#[async_trait(?Send)]
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 /// Cosign Abilities that have to be implemented by a
 /// Cosign client
 pub trait CosignCapabilities {

--- a/src/mock_client.rs
+++ b/src/mock_client.rs
@@ -33,7 +33,10 @@ pub(crate) mod test {
         pub push_response: Option<anyhow::Result<PushResponse>>,
     }
 
-    #[async_trait(?Send)]
+    impl crate::registry::ClientCapabilitiesDeps for MockOciClient {}
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl crate::registry::ClientCapabilities for MockOciClient {
         async fn fetch_manifest_digest(
             &mut self,

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -35,9 +35,30 @@ use crate::errors::Result;
 
 use async_trait::async_trait;
 
-#[async_trait(?Send)]
+/// Workaround to ensure the `Send + Sync` supertraits are
+/// required by ClientCapabilities only when the target
+/// architecture is NOT wasm32.
+///
+/// This intermediate trait has been created to avoid
+/// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
+/// the other with `#[cfg(not(target_arch = "wasm32"))]`
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
+
+/// Workaround to ensure the `Send + Sync` supertraits are
+/// required by ClientCapabilities only when the target
+/// architecture is NOT wasm32.
+///
+/// This intermediate trait has been created to avoid
+/// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
+/// the other with `#[cfg(not(target_arch = "wasm32"))]`
+#[cfg(target_arch = "wasm32")]
+pub(crate) trait ClientCapabilitiesDeps {}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 /// Capabilities that are expected to be provided by a registry client
-pub(crate) trait ClientCapabilities {
+pub(crate) trait ClientCapabilities: ClientCapabilitiesDeps {
     async fn fetch_manifest_digest(
         &mut self,
         image: &oci_distribution::Reference,

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::ClientCapabilities;
+use super::{ClientCapabilities, ClientCapabilitiesDeps};
 use crate::errors::{Result, SigstoreError};
 
 use async_trait::async_trait;
@@ -240,7 +240,10 @@ async fn pull_manifest_cached(
         .map(cached::Return::new)
 }
 
-#[async_trait(?Send)]
+impl ClientCapabilitiesDeps for OciCachingClient {}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl ClientCapabilities for OciCachingClient {
     async fn fetch_manifest_digest(
         &mut self,

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::ClientCapabilities;
+use super::{ClientCapabilities, ClientCapabilitiesDeps};
 use crate::errors::{Result, SigstoreError};
 
 use async_trait::async_trait;
@@ -27,7 +27,10 @@ pub(crate) struct OciClient {
     pub registry_client: oci_distribution::Client,
 }
 
-#[async_trait(?Send)]
+impl ClientCapabilitiesDeps for OciClient {}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl ClientCapabilities for OciClient {
     async fn fetch_manifest_digest(
         &mut self,


### PR DESCRIPTION
After d9b198ae4530a63932d8d674b1dd033fc08b0dfe got merged, the `Sync` and `Send` supertraits got removed from the `ClientCapabilities` trait. This was done to ensure the code could build when the `wasm32` target is used.

Unfortunately, this makes impossible to send the cosign client between threads. This causes an error like the following one:

```
error: future cannot be sent between threads safely
the trait `Send` is not implemented for `(dyn sigstore::registry::ClientCapabilities + 'static)`
```

This commit fixes the issue by introducing conditional compilation checks.
