### PR TITLE
chore(deps): update picky dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,8 @@ p256 = "0.13.2"
 p384 = "0.13"
 webbrowser = "0.8.4"
 pem = "2.0"
-picky = { version = "7.0.0-rc.5", default-features = false, features = [
+picky = { version = "7.0.0-rc.6", default-features = false, features = [
   "x509",
-  "ec",
 ] }
 pkcs1 = { version = "0.7.5", features = ["std"] }
 pkcs8 = { version = "0.10.2", features = [


### PR DESCRIPTION
Use latest RC of picky-rs. This RC now has elliptic curve support enabled by default, because of that the `ec` feature has been removed from the crate.
