### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.7.2
+
+## What's Changed
+* chore(deps): Update cached requirement from 0.42.0 to 0.44.0 by @dependabot in https://github.com/sigstore/sigstore-rs/pull/277
+* chore(deps): Bump actions/checkout from 3.5.2 to 3.5.3 by @dependabot in https://github.com/sigstore/sigstore-rs/pull/278
+* chore(deps): update picky dependency by @flavio in https://github.com/sigstore/sigstore-rs/pull/279
+
+**Full Changelog**: https://github.com/sigstore/sigstore-rs/compare/v0.7.1...v0.7.2
+
 # v0.7.1
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sigstore"
 description = "An experimental crate to interact with sigstore"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["sigstore-rs developers"]
 license = "Apache-2.0"


### PR DESCRIPTION
This is a patch release that bumps dependencies. The most significant upgrade is the `picky-rs` one.
