### PR TITLE
chore(deps): do not enable default features of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ async-trait = "0.1.52"
 base64 = "0.21.0"
 cached = { version = "0.44.0", optional = true }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.23" }
+chrono = { version = "0.4.23", default-features = false }
 const-oid = "0.9.1"
 digest = { version = "0.10.3", default-features = false }
 ecdsa = { version = "0.16.7", features = ["pkcs8", "digest", "der", "signing"] }


### PR DESCRIPTION
Enabling the default features of chrono causes the time 0.1 crate to be added as a transitive dependency.

This old version of time is affected by CVE RUSTSEC-2020-0071

Thanks to work done inside of chrono 0.4, there are high chances the majority of the codebases do not actually need it.

Building sigstore with only the cosign feature prevents the inclusion of the vulnerable time dependency.

This isn't unfortunately true when rekor is being used, because the openid crate brings the transitive dependency back.
