### PR TITLE
cosign: Allow use of regex in CertSubjectEmailVerifier

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 extern crate sigstore;
+use sigstore::cosign::verification_constraint::cert_subject_email_verifier::StringVerifier;
 use sigstore::cosign::verification_constraint::{
     AnnotationVerifier, CertSubjectEmailVerifier, CertSubjectUrlVerifier, CertificateVerifier,
     PublicKeyVerifier, VerificationConstraintVec,
@@ -146,10 +147,13 @@ async fn run_app(
     // Build verification constraints
     let mut verification_constraints: VerificationConstraintVec = Vec::new();
     if let Some(cert_email) = cli.cert_email.as_ref() {
-        let issuer = cli.cert_issuer.as_ref().map(|i| i.to_string());
+        let issuer = cli
+            .cert_issuer
+            .as_ref()
+            .map(|i| StringVerifier::ExactMatch(i.to_string()));
 
         verification_constraints.push(Box::new(CertSubjectEmailVerifier {
-            email: cert_email.to_string(),
+            email: StringVerifier::ExactMatch(cert_email.to_string()),
             issuer,
         }));
     }

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -286,6 +286,7 @@ mod tests {
     use webpki::types::CertificateDer;
 
     use super::constraint::{AnnotationMarker, PrivateKeySigner};
+    use super::verification_constraint::cert_subject_email_verifier::StringVerifier;
     use super::*;
     use crate::cosign::signature_layers::tests::build_correct_signature_layer_with_certificate;
     use crate::cosign::signature_layers::CertificateSubject;
@@ -389,13 +390,13 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
 
         let mut constraints: VerificationConstraintVec = Vec::new();
         let vc = CertSubjectEmailVerifier {
-            email: email.clone(),
-            issuer: Some(issuer),
+            email: StringVerifier::ExactMatch(email.clone()),
+            issuer: Some(StringVerifier::ExactMatch(issuer)),
         };
         constraints.push(Box::new(vc));
 
         let vc = CertSubjectEmailVerifier {
-            email,
+            email: StringVerifier::ExactMatch(email),
             issuer: None,
         };
         constraints.push(Box::new(vc));
@@ -438,13 +439,13 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
 
         let mut constraints: VerificationConstraintVec = Vec::new();
         let vc = CertSubjectEmailVerifier {
-            email: wrong_email.clone(),
-            issuer: Some(issuer), // correct issuer
+            email: StringVerifier::ExactMatch(wrong_email.clone()),
+            issuer: Some(StringVerifier::ExactMatch(issuer)), // correct issuer
         };
         constraints.push(Box::new(vc));
 
         let vc = CertSubjectEmailVerifier {
-            email: wrong_email,
+            email: StringVerifier::ExactMatch(wrong_email),
             issuer: None, // missing issuer, more relaxed
         };
         constraints.push(Box::new(vc));
@@ -486,13 +487,13 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
 
         let mut constraints: VerificationConstraintVec = Vec::new();
         let satisfied_constraint = CertSubjectEmailVerifier {
-            email,
-            issuer: Some(issuer),
+            email: StringVerifier::ExactMatch(email),
+            issuer: Some(StringVerifier::ExactMatch(issuer)),
         };
         constraints.push(Box::new(satisfied_constraint));
 
         let unsatisfied_constraint = CertSubjectEmailVerifier {
-            email: email_incorrect,
+            email: StringVerifier::ExactMatch(email_incorrect),
             issuer: None,
         };
         constraints.push(Box::new(unsatisfied_constraint));

--- a/src/cosign/verification_constraint/cert_subject_url_verifier.rs
+++ b/src/cosign/verification_constraint/cert_subject_url_verifier.rs
@@ -70,11 +70,15 @@ impl VerificationConstraint for CertSubjectUrlVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cosign::signature_layers::tests::{
-        build_correct_signature_layer_with_certificate,
-        build_correct_signature_layer_without_bundle,
+    use crate::cosign::{
+        signature_layers::tests::{
+            build_correct_signature_layer_with_certificate,
+            build_correct_signature_layer_without_bundle,
+        },
+        verification_constraint::{
+            cert_subject_email_verifier::StringVerifier, CertSubjectEmailVerifier,
+        },
     };
-    use crate::cosign::verification_constraint::CertSubjectEmailVerifier;
 
     #[test]
     fn cert_subject_url_verifier() {
@@ -108,8 +112,8 @@ mod tests {
 
         // A Cert email verifier should also report a non match
         let vc = CertSubjectEmailVerifier {
-            email: "alice@example.com".to_string(),
-            issuer: Some(issuer),
+            email: StringVerifier::ExactMatch("alice@example.com".to_string()),
+            issuer: Some(StringVerifier::ExactMatch(issuer)),
         };
         assert!(!vc.verify(&sl).unwrap());
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This allows for either an exact match [StringVerifier::ExactMatch]
or it allows for a regular expression [StringVerifier::Regex]

This supports the use case of trusting signatures from a
collection of email addresses e.g .*@redhat.com and or from a
collection of issuers.

Fixes: #299

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- `CertSubjectEmailVerifier` is now constructed using either a `StringVerifer` enum. This supports exact string matches or regular expressions.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Docstrings and examples are updated to show how this is used.