### PR TITLE
Fix broken tests, update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,14 +121,14 @@ url = "2.2.2"
 x509-cert = { version = "0.2.2", features = ["pem", "std"] }
 crypto_secretbox = "0.1.1"
 zeroize = "1.5.7"
-rustls-webpki = { version = "0.102.0-alpha.4", features = ["alloc"] }
-rustls-pki-types = { version = "0.2.1", features = ["std"] }
+rustls-webpki = { version = "0.102.0", features = ["alloc"] }
+rustls-pki-types = { version = "1.0.0", features = ["std"] }
 serde_repr = "0.1.16"
 
 [dev-dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 assert-json-diff = "2.0.2"
-chrono = "0.4.27"
+chrono = "0.4.31"
 clap = { version = "4.0.8", features = ["derive"] }
 docker_credential = "1.1.0"
 openssl = "0.10.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,9 +89,6 @@ p256 = "0.13.2"
 p384 = "0.13"
 webbrowser = "0.8.4"
 pem = "3.0"
-picky = { version = "7.0.0-rc.8", default-features = false, features = [
-  "x509",
-] }
 pkcs1 = { version = "0.7.5", features = ["std"] }
 pkcs8 = { version = "0.10.2", features = [
   "pem",

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -253,7 +253,7 @@ where
 /// [`SigstoreApplicationConstraintsError`]
 /// which contains a vector of references to unapplied constraints.
 ///
-/// See the documentation of the [`cosign::sign_constraint`](crate::cosign::sign_constraint) module for more
+/// See the documentation of the [`cosign::constraint`](crate::cosign::constraint) module for more
 /// details about how to define constraints.
 pub fn apply_constraints<'a, 'b, I>(
     signature_layer: &'a mut SignatureLayer,

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -98,8 +98,7 @@ pub enum CertificateSubject {
     Uri(String),
 }
 
-/// Object that contains all the data about a
-/// [`SimpleSigning`](crate::simple_signing::SimpleSigning) object.
+/// Object that contains all the data about a `SimpleSigning` object.
 ///
 /// The struct provides some helper methods that can be used at verification
 /// time.

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -39,7 +39,7 @@ impl<'a> CertificatePool<'a> {
         Ok(CertificatePool {
             trusted_roots: trusted_roots
                 .into_iter()
-                .map(|x| Ok(webpki::extract_trust_anchor(&x)?.to_owned()))
+                .map(|x| Ok(webpki::anchor_from_trusted_cert(&x)?.to_owned()))
                 .collect::<std::result::Result<Vec<_>, webpki::Error>>()?,
             intermediates: untrusted_intermediates.into_iter().collect(),
         })


### PR DESCRIPTION
This PR performs small fixes:

- docs: fix broken links
- deps: update to latest stable versions of chrono and webpki. This also fixes the broken test seen on https://github.com/sigstore/sigstore-rs/pull/312
- deps: remove picky-rs dependency. This closes https://github.com/sigstore/sigstore-rs/issues/308
