### PR TITLE
cargo audit: ignore RUSTSEC-2023-0071

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,9 +7,6 @@ ignore = [
                        # to API breakages.
                        #
                        # This is a transitive depependency of tough
-  "RUSTSEC-2021-0139",  # ansi_term is no longer maintained, however this is a transient dependency of
-                       # the `tracing-subscriber` crate, which is a dev_dependency and so therefore
-                       # will not be included in a release build.
   "RUSTSEC-2023-0071"  # "Classic" RSA timing sidechannel attack from non-constant-time implementation.
                        # Okay for local use.
                        # https://rustsec.org/advisories/RUSTSEC-2023-0071.html

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,7 +7,7 @@ ignore = [
                        # to API breakages.
                        #
                        # This is a transitive depependency of tough
-  "RUSTSEC-2021-0139"  # ansi_term is no longer maintained, however this is a transient dependency of
+  "RUSTSEC-2021-0139",  # ansi_term is no longer maintained, however this is a transient dependency of
                        # the `tracing-subscriber` crate, which is a dev_dependency and so therefore
                        # will not be included in a release build.
   "RUSTSEC-2023-0071"  # "Classic" RSA timing sidechannel attack from non-constant-time implementation.

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,7 @@ ignore = [
   "RUSTSEC-2021-0139"  # ansi_term is no longer maintained, however this is a transient dependency of
                        # the `tracing-subscriber` crate, which is a dev_dependency and so therefore
                        # will not be included in a release build.
+  "RUSTSEC-2023-0071"  # "Classic" RSA timing sidechannel attack from non-constant-time implementation.
+                       # Okay for local use.
+                       # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
 ]


### PR DESCRIPTION
[Current `cargo audit` workflow](https://github.com/trail-of-forks/sigstore-rs/actions/runs/7389952340/job/20103881623#step:3:9) is failing due to RSA timing sidechannel attack. Not relevant for this use (and to be refactored in #307), so add to `.cargo/audit.toml` ignorelist with rationale.

(CC @woodruffw)