### PR TITLE
lint: fix lint error of chrono and tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ rstest = "0.18.1"
 serial_test = "3.0.0"
 tempfile = "3.3.0"
 testcontainers = "0.15"
+tokio = { version = "1.17.0", features = ["rt", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 
 # cosign example mappings

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -876,7 +876,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
     use crate::cosign::bundle::Payload;
     use crate::crypto::tests::{generate_certificate, CertGenerationOptions};
     use crate::crypto::SigningScheme;
-    use chrono::{Duration, Utc};
+    use chrono::{TimeDelta, Utc};
 
     impl TryFrom<X509> for crate::registry::Certificate {
         type Error = anyhow::Error;
@@ -908,7 +908,9 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
             .try_into()?];
         let cert_pool = CertificatePool::from_certificates(certs, []).unwrap();
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now()
+            .checked_sub_signed(TimeDelta::try_minutes(1).unwrap())
+            .unwrap();
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {
@@ -957,7 +959,9 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
             .try_into()?];
         let cert_pool = CertificatePool::from_certificates(certs, []).unwrap();
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now()
+            .checked_sub_signed(TimeDelta::try_minutes(1).unwrap())
+            .unwrap();
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {
@@ -1005,7 +1009,9 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
             .try_into()?];
         let cert_pool = CertificatePool::from_certificates(certs, []).unwrap();
 
-        let integrated_time = Utc::now().checked_sub_signed(Duration::minutes(1)).unwrap();
+        let integrated_time = Utc::now()
+            .checked_sub_signed(TimeDelta::try_minutes(1).unwrap())
+            .unwrap();
         let bundle = Bundle {
             signed_entry_timestamp: "not relevant".to_string(),
             payload: Payload {

--- a/src/cosign/verification_constraint/certificate_verifier.rs
+++ b/src/cosign/verification_constraint/certificate_verifier.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use pkcs8::der::Decode;
 use std::convert::TryFrom;
 use tracing::warn;
@@ -89,9 +89,11 @@ impl VerificationConstraint for CertificateVerifier {
         match &signature_layer.bundle {
             Some(bundle) => {
                 let it = DateTime::<Utc>::from_naive_utc_and_offset(
-                    NaiveDateTime::from_timestamp_opt(bundle.payload.integrated_time, 0).ok_or(
-                        SigstoreError::UnexpectedError("timestamp is not legal".into()),
-                    )?,
+                    DateTime::from_timestamp(bundle.payload.integrated_time, 0)
+                        .ok_or(SigstoreError::UnexpectedError(
+                            "timestamp is not legal".into(),
+                        ))?
+                        .naive_utc(),
                     Utc,
                 );
                 let not_before: DateTime<Utc> =

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -190,7 +190,7 @@ pub mod signing_key;
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use chrono::{DateTime, Duration, Utc};
+    use chrono::{DateTime, TimeDelta, Utc};
     use openssl::asn1::{Asn1Integer, Asn1Time};
     use openssl::bn::{BigNum, MsbOption};
     use openssl::conf::{Conf, ConfMethod};
@@ -231,8 +231,12 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
 
     impl Default for CertGenerationOptions {
         fn default() -> Self {
-            let not_before = Utc::now().checked_sub_signed(Duration::days(1)).unwrap();
-            let not_after = Utc::now().checked_add_signed(Duration::days(1)).unwrap();
+            let not_before = Utc::now()
+                .checked_sub_signed(TimeDelta::try_days(1).unwrap())
+                .unwrap();
+            let not_after = Utc::now()
+                .checked_add_signed(TimeDelta::try_days(1).unwrap())
+                .unwrap();
 
             // Sigstore relies on NIST P-256
             // NIST P-256 is a Weierstrass curve specified in FIPS 186-4: Digital Signature Standard (DSS):


### PR DESCRIPTION
#### Summary

This PR mainly fixes the lint error of new chrono `0.4.35` who brings some breakthrough APIs.

Also, a `dev-dependency` of `tokio` with feature `rt-multi-thread` and `rt` is added to make the `example`s builtable.