### PR TITLE
feat: allow to create static instances of some objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
 const-oid = "0.9.1"
 digest = { version = "0.10.3", default-features = false }
+dyn-clone = "1.0"
 ecdsa = { version = "0.16.7", features = ["pkcs8", "digest", "der", "signing"] }
 ed25519 = { version = "2.2.1", features = ["alloc"] }
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["pkcs8", "rand_core"] }

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -28,6 +28,20 @@ pub(crate) struct CertificatePool<'a> {
     intermediates: Vec<CertificateDer<'a>>,
 }
 
+impl CertificatePool<'_> {
+    /// Yield a `'static` lifetime of the `CertificatePool`
+    pub(crate) fn to_owned(&self) -> CertificatePool<'static> {
+        CertificatePool {
+            trusted_roots: self.trusted_roots.iter().map(|ta| ta.to_owned()).collect(),
+            intermediates: self
+                .intermediates
+                .iter()
+                .map(|c| c.as_ref().to_owned().into())
+                .collect(),
+        }
+    }
+}
+
 impl<'a> CertificatePool<'a> {
     /// Builds a `CertificatePool` instance using the provided list of [`Certificate`].
     pub(crate) fn from_certificates<R, I>(

--- a/src/mock_client.rs
+++ b/src/mock_client.rs
@@ -24,13 +24,15 @@ pub(crate) mod test {
         secrets::RegistryAuth,
         Reference,
     };
+    use std::sync::Arc;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct MockOciClient {
-        pub fetch_manifest_digest_response: Option<anyhow::Result<String>>,
-        pub pull_response: Option<anyhow::Result<ImageData>>,
-        pub pull_manifest_response: Option<anyhow::Result<(OciManifest, String)>>,
-        pub push_response: Option<anyhow::Result<PushResponse>>,
+        // Note: all the `Result` objects have to be wrapped inside of an `Arc` to be able to clone them
+        pub fetch_manifest_digest_response: Option<Arc<anyhow::Result<String>>>,
+        pub pull_response: Option<Arc<anyhow::Result<ImageData>>>,
+        pub pull_manifest_response: Option<Arc<anyhow::Result<(OciManifest, String)>>>,
+        pub push_response: Option<Arc<anyhow::Result<PushResponse>>>,
     }
 
     impl crate::registry::ClientCapabilitiesDeps for MockOciClient {}
@@ -51,7 +53,7 @@ pub(crate) mod test {
                     error: String::from("No fetch_manifest_digest_response provided!"),
                 })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryFetchManifestError {
                     image: image.whole(),
@@ -74,7 +76,7 @@ pub(crate) mod test {
                         error: String::from("No pull_response provided!"),
                     })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryPullError {
                     image: image.whole(),
@@ -95,7 +97,7 @@ pub(crate) mod test {
                 }
             })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryPullError {
                     image: image.whole(),
@@ -120,7 +122,7 @@ pub(crate) mod test {
                         error: String::from("No push_response provided!"),
                     })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(PushResponse {
                     config_url: r.config_url.clone(),
                     manifest_url: r.manifest_url.clone(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use oci_caching_client::*;
 use crate::errors::Result;
 
 use async_trait::async_trait;
+use dyn_clone::DynClone;
 
 /// Workaround to ensure the `Send + Sync` supertraits are
 /// required by ClientCapabilities only when the target
@@ -43,7 +44,7 @@ use async_trait::async_trait;
 /// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
 /// the other with `#[cfg(not(target_arch = "wasm32"))]`
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
+pub(crate) trait ClientCapabilitiesDeps: Send + Sync + DynClone {}
 
 /// Workaround to ensure the `Send + Sync` supertraits are
 /// required by ClientCapabilities only when the target
@@ -53,7 +54,7 @@ pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
 /// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
 /// the other with `#[cfg(not(target_arch = "wasm32"))]`
 #[cfg(target_arch = "wasm32")]
-pub(crate) trait ClientCapabilitiesDeps {}
+pub(crate) trait ClientCapabilitiesDeps: DynClone {}
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -87,3 +88,5 @@ pub(crate) trait ClientCapabilities: ClientCapabilitiesDeps {
         manifest: Option<oci_distribution::manifest::OciImageManifest>,
     ) -> Result<oci_distribution::client::PushResponse>;
 }
+
+dyn_clone::clone_trait_object!(ClientCapabilities);

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error};
 ///
 /// For testing purposes, use instead the client inside of the
 /// `mock_client` module.
+#[derive(Clone)]
 pub(crate) struct OciCachingClient {
     pub registry_client: oci_distribution::Client,
 }

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 ///
 /// For testing purposes, use instead the client inside of the
 /// `mock_client` module.
+#[derive(Clone)]
 pub(crate) struct OciClient {
     pub registry_client: oci_distribution::Client,
 }


### PR DESCRIPTION
Allow to create `static` instances of the `cosign::Client`, `sigstore::trust::ManualTrustRoot`.

The ability to create `static` instances of these objects can simplify the downstream consumers of this library.

The approach taken to create these `static` instance is the same used by [`rustls_pki_types::CertificateDer::into_owned`](https://docs.rs/rustls-pki-types/1.4.1/rustls_pki_types/struct.CertificateDer.html#method.into_owned)
