### PR TITLE
fix: allow `ManualTrustRoot` to hold multiple Rekor keys

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -237,10 +237,8 @@ async fn fulcio_and_rekor_data(cli: &Cli) -> anyhow::Result<Box<dyn sigstore::tr
 
     let mut data = sigstore::trust::ManualTrustRoot::default();
     if let Some(path) = cli.rekor_pub_key.as_ref() {
-        data.rekor_key = Some(
-            fs::read(path)
-                .map_err(|e| anyhow!("Error reading rekor public key from disk: {}", e))?,
-        );
+        data.rekor_keys = Some(vec![fs::read(path)
+            .map_err(|e| anyhow!("Error reading rekor public key from disk: {}", e))?]);
     }
 
     if let Some(path) = cli.fulcio_cert.as_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //!   let mut repo = sigstore::trust::ManualTrustRoot {
 //!     fulcio_certs: Some(vec![fulcio_cert.try_into().unwrap()]),
-//!     rekor_key: Some(rekor_pub_key),
+//!     rekor_keys: Some(vec![rekor_pub_key]),
 //!     ..Default::default()
 //!   };
 //!

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -32,7 +32,7 @@ pub trait TrustRoot: Send + Sync {
 #[derive(Debug, Default)]
 pub struct ManualTrustRoot<'a> {
     pub fulcio_certs: Option<Vec<CertificateDer<'a>>>,
-    pub rekor_key: Option<Vec<u8>>,
+    pub rekor_keys: Option<Vec<Vec<u8>>>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -47,8 +47,8 @@ impl TrustRoot for ManualTrustRoot<'_> {
     }
 
     async fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {
-        Ok(match &self.rekor_key {
-            Some(key) => vec![&key[..]],
+        Ok(match &self.rekor_keys {
+            Some(keys) => keys.iter().map(|k| k.as_slice()).collect(),
             None => Vec::new(),
         })
     }

--- a/src/trust/sigstore/mod.rs
+++ b/src/trust/sigstore/mod.rs
@@ -312,15 +312,24 @@ fn is_local_file_outdated(
 
 #[cfg(test)]
 mod tests {
-    use crate::trust::sigstore::SigstoreTrustRoot;
+    use super::*;
 
     #[tokio::test]
     async fn prefetch() {
-        let _repo = SigstoreTrustRoot::new(None)
+        let repo = SigstoreTrustRoot::new(None)
             .await
             .expect("initialize SigstoreRepository")
             .prefetch()
             .await
             .expect("prefetch");
+
+        let fulcio_certs = repo
+            .fulcio_certs()
+            .await
+            .expect("cannot fetch Fulcio certs");
+        assert!(!fulcio_certs.is_empty());
+
+        let rekor_keys = repo.rekor_keys().await.expect("cannot fetch Rekor keys");
+        assert!(!rekor_keys.is_empty());
     }
 }


### PR DESCRIPTION
The `sigstore::trust::sigstore::SigstoreTrustRoot` can hold multiple Rekor keys.

The possibility to have multiple keys is also reflected by the [`sigstore::trust::TrustRoot.rekor_keys`](https://docs.rs/sigstore/0.9.0/sigstore/trust/trait.TrustRoot.html#tymethod.rekor_keys) trait.

This commit allows the `ManualTrustRoot` object to hold multiple Rekor keys.
