### PR TITLE
remove async from trustroot trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
 const-oid = "0.9.1"
 digest = { version = "0.10.3", default-features = false }
+dyn-clone = "1.0"
 ecdsa = { version = "0.16.7", features = ["pkcs8", "digest", "der", "signing"] }
 ed25519 = { version = "2.2.1", features = ["alloc"] }
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["pkcs8", "rand_core"] }

--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -237,10 +237,8 @@ async fn fulcio_and_rekor_data(cli: &Cli) -> anyhow::Result<Box<dyn sigstore::tr
 
     let mut data = sigstore::trust::ManualTrustRoot::default();
     if let Some(path) = cli.rekor_pub_key.as_ref() {
-        data.rekor_key = Some(
-            fs::read(path)
-                .map_err(|e| anyhow!("Error reading rekor public key from disk: {}", e))?,
-        );
+        data.rekor_keys = Some(vec![fs::read(path)
+            .map_err(|e| anyhow!("Error reading rekor public key from disk: {}", e))?]);
     }
 
     if let Some(path) = cli.fulcio_cert.as_ref() {

--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -130,7 +130,7 @@ async fn run_app(
 
     let mut client_builder =
         sigstore::cosign::ClientBuilder::default().with_oci_client_config(oci_client_config);
-    client_builder = client_builder.with_trust_repository(frd).await?;
+    client_builder = client_builder.with_trust_repository(frd)?;
 
     let cert_chain: Option<Vec<sigstore::registry::Certificate>> = match cli.cert_chain.as_ref() {
         None => None,
@@ -184,7 +184,7 @@ async fn run_app(
     }
     if let Some(path_to_cert) = cli.cert.as_ref() {
         let cert = fs::read(path_to_cert).map_err(|e| anyhow!("Cannot read cert: {:?}", e))?;
-        let require_rekor_bundle = if !frd.rekor_keys().await?.is_empty() {
+        let require_rekor_bundle = if !frd.rekor_keys()?.is_empty() {
             true
         } else {
             warn!("certificate based verification is weaker when Rekor integration is disabled");
@@ -229,8 +229,7 @@ async fn fulcio_and_rekor_data(cli: &Cli) -> anyhow::Result<Box<dyn sigstore::tr
     if cli.use_sigstore_tuf_data {
         info!("Downloading data from Sigstore TUF repository");
 
-        let repo: sigstore::errors::Result<SigstoreTrustRoot> =
-            SigstoreTrustRoot::new(None).await?.prefetch().await;
+        let repo: sigstore::errors::Result<SigstoreTrustRoot> = SigstoreTrustRoot::new(None).await;
 
         return Ok(Box::new(repo?));
     };

--- a/src/cosign/client_builder.rs
+++ b/src/cosign/client_builder.rs
@@ -72,15 +72,12 @@ impl<'a> ClientBuilder<'a> {
     ///
     /// Enables Fulcio and Rekor integration with the given trust repository.
     /// See [crate::sigstore::TrustRoot] for more details on trust repositories.
-    pub async fn with_trust_repository<R: TrustRoot + ?Sized>(
-        mut self,
-        repo: &'a R,
-    ) -> Result<Self> {
-        let rekor_keys = repo.rekor_keys().await?;
+    pub fn with_trust_repository<R: TrustRoot + ?Sized>(mut self, repo: &'a R) -> Result<Self> {
+        let rekor_keys = repo.rekor_keys()?;
         if !rekor_keys.is_empty() {
             self.rekor_pub_key = Some(rekor_keys[0]);
         }
-        self.fulcio_certs = repo.fulcio_certs().await?;
+        self.fulcio_certs = repo.fulcio_certs()?;
 
         Ok(self)
     }

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -28,6 +28,20 @@ pub(crate) struct CertificatePool<'a> {
     intermediates: Vec<CertificateDer<'a>>,
 }
 
+impl CertificatePool<'_> {
+    /// Yield a `'static` lifetime of the `CertificatePool`
+    pub(crate) fn to_owned(&self) -> CertificatePool<'static> {
+        CertificatePool {
+            trusted_roots: self.trusted_roots.iter().map(|ta| ta.to_owned()).collect(),
+            intermediates: self
+                .intermediates
+                .iter()
+                .map(|c| c.as_ref().to_owned().into())
+                .collect(),
+        }
+    }
+}
+
 impl<'a> CertificatePool<'a> {
     /// Builds a `CertificatePool` instance using the provided list of [`Certificate`].
     pub(crate) fn from_certificates<R, I>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //!   let mut repo = sigstore::trust::ManualTrustRoot {
 //!     fulcio_certs: Some(vec![fulcio_cert.try_into().unwrap()]),
-//!     rekor_key: Some(rekor_pub_key),
+//!     rekor_keys: Some(vec![rekor_pub_key]),
 //!     ..Default::default()
 //!   };
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@
 //!
 //!   let mut client = sigstore::cosign::ClientBuilder::default()
 //!     .with_trust_repository(&repo)
-//!     .await
 //!     .expect("Cannot construct cosign client from given materials")
 //!     .build()
 //!     .expect("Unexpected failure while building Client");

--- a/src/mock_client.rs
+++ b/src/mock_client.rs
@@ -24,13 +24,15 @@ pub(crate) mod test {
         secrets::RegistryAuth,
         Reference,
     };
+    use std::sync::Arc;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct MockOciClient {
-        pub fetch_manifest_digest_response: Option<anyhow::Result<String>>,
-        pub pull_response: Option<anyhow::Result<ImageData>>,
-        pub pull_manifest_response: Option<anyhow::Result<(OciManifest, String)>>,
-        pub push_response: Option<anyhow::Result<PushResponse>>,
+        // Note: all the `Result` objects have to be wrapped inside of an `Arc` to be able to clone them
+        pub fetch_manifest_digest_response: Option<Arc<anyhow::Result<String>>>,
+        pub pull_response: Option<Arc<anyhow::Result<ImageData>>>,
+        pub pull_manifest_response: Option<Arc<anyhow::Result<(OciManifest, String)>>>,
+        pub push_response: Option<Arc<anyhow::Result<PushResponse>>>,
     }
 
     impl crate::registry::ClientCapabilitiesDeps for MockOciClient {}
@@ -51,7 +53,7 @@ pub(crate) mod test {
                     error: String::from("No fetch_manifest_digest_response provided!"),
                 })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryFetchManifestError {
                     image: image.whole(),
@@ -74,7 +76,7 @@ pub(crate) mod test {
                         error: String::from("No pull_response provided!"),
                     })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryPullError {
                     image: image.whole(),
@@ -95,7 +97,7 @@ pub(crate) mod test {
                 }
             })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(SigstoreError::RegistryPullError {
                     image: image.whole(),
@@ -120,7 +122,7 @@ pub(crate) mod test {
                         error: String::from("No push_response provided!"),
                     })?;
 
-            match mock_response {
+            match mock_response.as_ref() {
                 Ok(r) => Ok(PushResponse {
                     config_url: r.config_url.clone(),
                     manifest_url: r.manifest_url.clone(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use oci_caching_client::*;
 use crate::errors::Result;
 
 use async_trait::async_trait;
+use dyn_clone::DynClone;
 
 /// Workaround to ensure the `Send + Sync` supertraits are
 /// required by ClientCapabilities only when the target
@@ -43,7 +44,7 @@ use async_trait::async_trait;
 /// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
 /// the other with `#[cfg(not(target_arch = "wasm32"))]`
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
+pub(crate) trait ClientCapabilitiesDeps: Send + Sync + DynClone {}
 
 /// Workaround to ensure the `Send + Sync` supertraits are
 /// required by ClientCapabilities only when the target
@@ -53,7 +54,7 @@ pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
 /// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
 /// the other with `#[cfg(not(target_arch = "wasm32"))]`
 #[cfg(target_arch = "wasm32")]
-pub(crate) trait ClientCapabilitiesDeps {}
+pub(crate) trait ClientCapabilitiesDeps: DynClone {}
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -87,3 +88,5 @@ pub(crate) trait ClientCapabilities: ClientCapabilitiesDeps {
         manifest: Option<oci_distribution::manifest::OciImageManifest>,
     ) -> Result<oci_distribution::client::PushResponse>;
 }
+
+dyn_clone::clone_trait_object!(ClientCapabilities);

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error};
 ///
 /// For testing purposes, use instead the client inside of the
 /// `mock_client` module.
+#[derive(Clone)]
 pub(crate) struct OciCachingClient {
     pub registry_client: oci_distribution::Client,
 }

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 ///
 /// For testing purposes, use instead the client inside of the
 /// `mock_client` module.
+#[derive(Clone)]
 pub(crate) struct OciClient {
     pub registry_client: oci_distribution::Client,
 }

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -13,18 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use webpki::types::CertificateDer;
 
 #[cfg(feature = "sigstore-trust-root")]
 pub mod sigstore;
 
 /// A `TrustRoot` owns all key material necessary for establishing a root of trust.
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait TrustRoot: Send + Sync {
-    async fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>>;
-    async fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>>;
+    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>>;
+    fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>>;
 }
 
 /// A `ManualTrustRoot` is a [TrustRoot] with out-of-band trust materials.
@@ -36,17 +33,16 @@ pub struct ManualTrustRoot<'a> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-#[async_trait]
 impl TrustRoot for ManualTrustRoot<'_> {
     #[cfg(not(target_arch = "wasm32"))]
-    async fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>> {
+    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>> {
         Ok(match &self.fulcio_certs {
             Some(certs) => certs.clone(),
             None => Vec::new(),
         })
     }
 
-    async fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {
+    fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {
         Ok(match &self.rekor_keys {
             Some(keys) => keys.iter().map(|k| k.as_slice()).collect(),
             None => Vec::new(),

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -32,7 +32,7 @@ pub trait TrustRoot: Send + Sync {
 #[derive(Debug, Default)]
 pub struct ManualTrustRoot<'a> {
     pub fulcio_certs: Option<Vec<CertificateDer<'a>>>,
-    pub rekor_key: Option<Vec<u8>>,
+    pub rekor_keys: Option<Vec<Vec<u8>>>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -47,8 +47,8 @@ impl TrustRoot for ManualTrustRoot<'_> {
     }
 
     async fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {
-        Ok(match &self.rekor_key {
-            Some(key) => vec![&key[..]],
+        Ok(match &self.rekor_keys {
+            Some(keys) => keys.iter().map(|k| k.as_slice()).collect(),
             None => Vec::new(),
         })
     }

--- a/src/trust/sigstore/mod.rs
+++ b/src/trust/sigstore/mod.rs
@@ -312,15 +312,24 @@ fn is_local_file_outdated(
 
 #[cfg(test)]
 mod tests {
-    use crate::trust::sigstore::SigstoreTrustRoot;
+    use super::*;
 
     #[tokio::test]
     async fn prefetch() {
-        let _repo = SigstoreTrustRoot::new(None)
+        let repo = SigstoreTrustRoot::new(None)
             .await
             .expect("initialize SigstoreRepository")
             .prefetch()
             .await
             .expect("prefetch");
+
+        let fulcio_certs = repo
+            .fulcio_certs()
+            .await
+            .expect("cannot fetch Fulcio certs");
+        assert!(!fulcio_certs.is_empty());
+
+        let rekor_keys = repo.rekor_keys().await.expect("cannot fetch Rekor keys");
+        assert!(!rekor_keys.is_empty());
     }
 }


### PR DESCRIPTION
**Note:** this PR builds on top of https://github.com/sigstore/sigstore-rs/pull/348 and https://github.com/sigstore/sigstore-rs/pull/349. I'll rebase it once those are merged.

This PR makes the methods defined inside of the `sigstore::trust::TrustRoot` trait non-async. This fixes https://github.com/sigstore/sigstore-rs/issues/346
