### PR TITLE
fix: allow ManualTrustRoot to have multiple rekor keys

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -63,11 +63,11 @@ struct Cli {
 
     /// File containing Rekor's public key (e.g.: ~/.sigstore/root/targets/rekor.pub)
     #[clap(long, required(false))]
-    rekor_pub_key: Option<String>,
+    rekor_pub_keys: Vec<String>,
 
     /// File containing Fulcio's certificate (e.g.: ~/.sigstore/root/targets/fulcio.crt.pem)
     #[clap(long, required(false))]
-    fulcio_cert: Option<String>,
+    fulcio_certs: Vec<String>,
 
     /// The issuer of the OIDC token used by the user to authenticate against Fulcio
     #[clap(long, required(false))]
@@ -235,14 +235,14 @@ async fn fulcio_and_rekor_data(cli: &Cli) -> anyhow::Result<Box<dyn sigstore::tr
     };
 
     let mut data = sigstore::trust::ManualTrustRoot::default();
-    if let Some(path) = cli.rekor_pub_key.as_ref() {
-        data.rekor_key = Some(
+    for path in cli.rekor_pub_keys.iter() {
+        data.rekor_keys.push(
             fs::read(path)
                 .map_err(|e| anyhow!("Error reading rekor public key from disk: {}", e))?,
         );
     }
 
-    if let Some(path) = cli.fulcio_cert.as_ref() {
+    for path in cli.fulcio_certs.iter() {
         let cert_data = fs::read(path)
             .map_err(|e| anyhow!("Error reading fulcio certificate from disk: {}", e))?;
 
@@ -250,9 +250,7 @@ async fn fulcio_and_rekor_data(cli: &Cli) -> anyhow::Result<Box<dyn sigstore::tr
             encoding: sigstore::registry::CertificateEncoding::Pem,
             data: cert_data,
         };
-        data.fulcio_certs
-            .get_or_insert(Vec::new())
-            .push(certificate.try_into()?);
+        data.fulcio_certs.push(certificate.try_into()?);
     }
 
     Ok(Box::new(data))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@
 //!   };
 //!
 //!   let mut repo = sigstore::trust::ManualTrustRoot {
-//!     fulcio_certs: Some(vec![fulcio_cert.try_into().unwrap()]),
-//!     rekor_key: Some(rekor_pub_key),
+//!     fulcio_certs: vec![fulcio_cert.try_into().unwrap()],
+//!     rekor_keys: vec![rekor_pub_key],
 //!     ..Default::default()
 //!   };
 //!

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -29,24 +29,18 @@ pub trait TrustRoot {
 /// As it does not establish a trust root with TUF, users must initialize its materials themselves.
 #[derive(Debug, Default)]
 pub struct ManualTrustRoot<'a> {
-    pub fulcio_certs: Option<Vec<CertificateDer<'a>>>,
-    pub rekor_key: Option<Vec<u8>>,
+    pub fulcio_certs: Vec<CertificateDer<'a>>,
+    pub rekor_keys: Vec<Vec<u8>>,
     pub ctfe_keys: Vec<Vec<u8>>,
 }
 
 impl TrustRoot for ManualTrustRoot<'_> {
     fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>> {
-        Ok(match &self.fulcio_certs {
-            Some(certs) => certs.clone(),
-            None => Vec::new(),
-        })
+        Ok(self.fulcio_certs.clone())
     }
 
     fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {
-        Ok(match &self.rekor_key {
-            Some(key) => vec![&key[..]],
-            None => Vec::new(),
-        })
+        Ok(self.rekor_keys.iter().map(|key| &key[..]).collect())
     }
 
     fn ctfe_keys(&self) -> crate::errors::Result<Vec<&[u8]>> {


### PR DESCRIPTION
`ManualTrustRoot` implements the `TrustRoot` trait, which requires the implemented to have multiple rekor keys. The `ManualTrustRoot` struct has now been updated to handle that, prior to that only one Rekor key was stored inside of a `ManualTrustRoot` instance.
