### PR TITLE
chore: update cargo audit ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,13 +1,8 @@
 [advisories]
 ignore = [
-  "RUSTSEC-2020-0071", # `time` localtime_r segfault -- https://rustsec.org/advisories/RUSTSEC-2020-0071
-                       # This vulnerability is currently not affecting chrono 0.4.20+
-                       # See https://github.com/chronotope/chrono/issues/602
-                       # Chrono 0.5 will upgrade this depependency, but this will lead
-                       # to API breakages.
-                       #
-                       # This is a transitive depependency of tough
-  "RUSTSEC-2023-0071"  # "Classic" RSA timing sidechannel attack from non-constant-time implementation.
-                       # Okay for local use.
-                       # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
+  "RUSTSEC-2023-0071", # "Classic" RSA timing sidechannel attack from non-constant-time implementation.
+  # Okay for local use.
+  # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
+  "RUSTSEC-2024-0370", # This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
+  "RUSTSEC-2023-0055", # This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.
 ]


### PR DESCRIPTION
A bunch of warnings have popped up. There's nothing we can do about them and they basically no impact on us.

- "RUSTSEC-2024-0370": This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
- "RUSTSEC-2023-0055": This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.

Also, stop ignoring "RUSTSEC-2020-0071" since the issue has been fixed by our transitive dependency.
