### PR TITLE
Cosign | Add support for client to configure a proxy to pull signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,13 +67,13 @@ sigstore-trust-root-rustls-tls = [
 ]
 
 cosign-native-tls = [
-  "oci-distribution/native-tls",
+  "oci-client/native-tls",
   "cert",
   "cosign",
   "registry-native-tls",
 ]
 cosign-rustls-tls = [
-  "oci-distribution/rustls-tls",
+  "oci-client/rustls-tls",
   "cert",
   "cosign",
   "registry-rustls-tls",
@@ -81,12 +81,12 @@ cosign-rustls-tls = [
 cosign = ["olpc-cjson"]
 cert = []
 
-registry-native-tls = ["oci-distribution/native-tls", "registry"]
-registry-rustls-tls = ["oci-distribution/rustls-tls", "registry"]
+registry-native-tls = ["oci-client/native-tls", "registry"]
+registry-rustls-tls = ["oci-client/rustls-tls", "registry"]
 registry = ["olpc-cjson"]
 
-mock-client-native-tls = ["oci-distribution/native-tls", "mock-client"]
-mock-client-rustls-tls = ["oci-distribution/rustls-tls", "mock-client"]
+mock-client-native-tls = ["oci-client/native-tls", "mock-client"]
+mock-client-rustls-tls = ["oci-client/rustls-tls", "mock-client"]
 mock-client = []
 
 cached-client = ["cached"]
@@ -109,7 +109,7 @@ elliptic-curve = { version = "0.13", features = ["arithmetic", "pem"] }
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }
 lazy_static = "1.5"
-oci-distribution = { version = "0.11", default-features = false, optional = true }
+oci-client = { default-features = false, optional = true, version = "0.13" }
 olpc-cjson = { version = "0.1", optional = true }
 openidconnect = { version = "3.5", default-features = false, features = [
   "reqwest",

--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -24,14 +24,13 @@ use sigstore::errors::SigstoreVerifyConstraintsError;
 use sigstore::registry::{ClientConfig, ClientProtocol, OciReference};
 use sigstore::trust::sigstore::SigstoreTrustRoot;
 use std::time::Instant;
+use std::{collections::BTreeMap, fs};
 
 extern crate anyhow;
 use anyhow::{anyhow, Result};
 
 extern crate clap;
 use clap::Parser;
-
-use std::{collections::HashMap, fs};
 
 extern crate tracing_subscriber;
 use tracing::{info, warn};
@@ -199,7 +198,7 @@ async fn run_app(
     }
 
     if !cli.annotations.is_empty() {
-        let mut values: HashMap<String, String> = HashMap::new();
+        let mut values: BTreeMap<String, String> = BTreeMap::new();
         for annotation in &cli.annotations {
             let tmp: Vec<_> = annotation.splitn(2, '=').collect();
             if tmp.len() == 2 {

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ops::Add;
 
 use async_trait::async_trait;
-use oci_distribution::manifest::OCI_IMAGE_MEDIA_TYPE;
+use oci_client::manifest::OCI_IMAGE_MEDIA_TYPE;
 use tracing::warn;
 
 use super::constants::{SIGSTORE_OCI_MEDIA_TYPE, SIGSTORE_SIGNATURE_ANNOTATION};
@@ -73,8 +73,8 @@ impl CosignCapabilities for Client {
     ) -> Result<Vec<SignatureLayer>> {
         let (manifest, layers) = self.fetch_manifest_and_layers(auth, cosign_image).await?;
         let image_manifest = match manifest {
-            oci_distribution::manifest::OciManifest::Image(im) => im,
-            oci_distribution::manifest::OciManifest::ImageIndex(_) => {
+            oci_client::manifest::OciManifest::Image(im) => im,
+            oci_client::manifest::OciManifest::ImageIndex(_) => {
                 return Err(SigstoreError::RegistryPullManifestError {
                     image: cosign_image.to_string(),
                     error: "Found a OciImageIndex instead of a OciImageManifest".to_string(),
@@ -96,21 +96,21 @@ impl CosignCapabilities for Client {
 
     async fn push_signature(
         &mut self,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
         auth: &Auth,
         target_reference: &OciReference,
         signature_layers: Vec<SignatureLayer>,
     ) -> Result<PushResponse> {
-        let layers: Vec<oci_distribution::client::ImageLayer> = signature_layers
+        let layers: Vec<oci_client::client::ImageLayer> = signature_layers
             .iter()
             .filter_map(|sl| {
                 match serde_json::to_vec(&sl.simple_signing) {
                     Ok(data) => {
                         let annotations = match &sl.signature {
                             Some(sig) => [(SIGSTORE_SIGNATURE_ANNOTATION.into(), sig.clone())].into(),
-                            None => HashMap::new(),
+                            None => BTreeMap::new(),
                         };
-                        let image_layer = oci_distribution::client::ImageLayer::new(data, SIGSTORE_OCI_MEDIA_TYPE.into(), Some(annotations));
+                        let image_layer = oci_client::client::ImageLayer::new(data, SIGSTORE_OCI_MEDIA_TYPE.into(), Some(annotations));
                         Some(image_layer)
                     }
                     Err(e) => {
@@ -122,10 +122,9 @@ impl CosignCapabilities for Client {
             .collect();
 
         // TODO: Do we need to support OCI Image Configuration?
-        let config =
-            oci_distribution::client::Config::oci_v1(CONFIG_DATA.as_bytes().to_vec(), None);
+        let config = oci_client::client::Config::oci_v1(CONFIG_DATA.as_bytes().to_vec(), None);
         let mut manifest =
-            oci_distribution::manifest::OciImageManifest::build(&layers[..], &config, annotations);
+            oci_client::manifest::OciImageManifest::build(&layers[..], &config, annotations);
         manifest.media_type = Some(OCI_IMAGE_MEDIA_TYPE.to_string());
         self.registry_client
             .push(
@@ -147,10 +146,10 @@ impl Client {
         auth: &Auth,
         cosign_image: &OciReference,
     ) -> Result<(
-        oci_distribution::manifest::OciManifest,
-        Vec<oci_distribution::client::ImageLayer>,
+        oci_client::manifest::OciManifest,
+        Vec<oci_client::client::ImageLayer>,
     )> {
-        let oci_auth: oci_distribution::secrets::RegistryAuth = auth.into();
+        let oci_auth: oci_client::secrets::RegistryAuth = auth.into();
 
         let (manifest, _) = self
             .registry_client

--- a/src/cosign/client_builder.rs
+++ b/src/cosign/client_builder.rs
@@ -112,8 +112,7 @@ impl<'a> ClientBuilder<'a> {
             Some(cert_pool)
         };
 
-        let oci_client =
-            oci_distribution::client::Client::new(self.oci_client_config.clone().into());
+        let oci_client = oci_client::client::Client::new(self.oci_client_config.clone().into());
 
         let registry_client: Box<dyn crate::registry::ClientCapabilities> = {
             cfg_if::cfg_if! {

--- a/src/cosign/constraint/annotation.rs
+++ b/src/cosign/constraint/annotation.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde_json::Value;
 use tracing::warn;
@@ -50,7 +50,7 @@ impl Constraint for AnnotationMarker {
                 warn!(optional = ?opt, "already has an annotation field");
                 opt.extra.clone()
             }
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         for (k, v) in &self.annotations {

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -36,7 +36,7 @@
 //! In case you want to mock sigstore interactions inside of your own code, you
 //! can implement the [`CosignCapabilities`] trait inside of your test suite.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use tracing::warn;
@@ -126,9 +126,9 @@ pub trait CosignCapabilities {
 
     /// Push [`SignatureLayer`] objects to the registry. This function will do
     /// the following steps:
-    /// * Generate a series of [`oci_distribution::client::ImageLayer`]s due to
+    /// * Generate a series of [`oci_client::client::ImageLayer`]s due to
     /// the given [`Vec<SignatureLayer>`].
-    /// * Generate a `OciImageManifest` of [`oci_distribution::manifest::OciManifest`]
+    /// * Generate a `OciImageManifest` of [`oci_client::manifest::OciManifest`]
     /// due to the given `source_image_digest` and `signature_layers`. It supports
     /// to be extended when newly published
     /// [Referrers API of OCI Registry v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers),
@@ -146,7 +146,7 @@ pub trait CosignCapabilities {
     /// - `signature_layers`: [`SignatureLayer`] objects containing signature information
     async fn push_signature(
         &mut self,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
         auth: &Auth,
         target_reference: &OciReference,
         signature_layers: Vec<SignatureLayer>,
@@ -356,7 +356,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
         let email = "alice@example.com".to_string();
         let issuer = "an issuer".to_string();
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert("key1".into(), "value1".into());
         annotations.insert("key2".into(), "value2".into());
 
@@ -369,7 +369,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
             cert_signature.subject = cert_subj;
             sl.certificate_signature = Some(cert_signature);
 
-            let mut extra: HashMap<String, serde_json::Value> = annotations
+            let mut extra: BTreeMap<String, serde_json::Value> = annotations
                 .iter()
                 .map(|(k, v)| (k.clone(), json!(v)))
                 .collect();
@@ -421,7 +421,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
             cert_signature.subject = cert_subj;
             sl.certificate_signature = Some(cert_signature);
 
-            let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+            let mut extra: BTreeMap<String, serde_json::Value> = BTreeMap::new();
             extra.insert("something extra".into(), json!("value extra"));
 
             let mut simple_signing = sl.simple_signing;
@@ -469,7 +469,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
             cert_signature.subject = cert_subj;
             sl.certificate_signature = Some(cert_signature);
 
-            let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+            let mut extra: BTreeMap<String, serde_json::Value> = BTreeMap::new();
             extra.insert("something extra".into(), json!("value extra"));
 
             let mut simple_signing = sl.simple_signing;
@@ -651,8 +651,8 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
             .registry_client
             .pull(
                 &SIGNED_IMAGE.parse().expect("failed to parse image ref"),
-                &oci_distribution::secrets::RegistryAuth::Anonymous,
-                vec![oci_distribution::manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE],
+                &oci_client::secrets::RegistryAuth::Anonymous,
+                vec![oci_client::manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE],
             )
             .await
             .expect("pull test image failed");
@@ -663,7 +663,7 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
                 &image_ref.oci_reference,
                 &data.layers[..],
                 data.config.clone(),
-                &oci_distribution::secrets::RegistryAuth::Anonymous,
+                &oci_client::secrets::RegistryAuth::Anonymous,
                 None,
             )
             .await

--- a/src/cosign/payload/simple_signing.rs
+++ b/src/cosign/payload/simple_signing.rs
@@ -21,7 +21,7 @@ use crate::registry::OciReference;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, fmt};
+use std::{collections::BTreeMap, fmt};
 use tracing::{debug, error, info};
 
 /// Default type name of [`Critical`] when doing cosign signing
@@ -65,7 +65,7 @@ impl SimpleSigning {
     }
 
     /// Checks whether all the provided `annotations` are satisfied
-    pub fn satisfies_annotations(&self, annotations: &HashMap<String, String>) -> bool {
+    pub fn satisfies_annotations(&self, annotations: &BTreeMap<String, String>) -> bool {
         if annotations.is_empty() {
             debug!("no annotations have been provided -> returning true");
             return true;
@@ -128,12 +128,12 @@ pub struct Optional {
     pub timestamp: Option<i64>,
 
     #[serde(flatten)]
-    pub extra: HashMap<String, Value>,
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl Optional {
     /// Checks whether all the provided `annotations` are satisfied
-    pub fn satisfies_annotations(&self, annotations: &HashMap<String, String>) -> bool {
+    pub fn satisfies_annotations(&self, annotations: &BTreeMap<String, String>) -> bool {
         if self.extra.is_empty() {
             info!(?annotations, "Annotations are not satisfied, no annotations are part of the Simple Signing object");
             return false;
@@ -221,7 +221,7 @@ mod tests {
         });
         let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap();
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(String::from("env"), String::from("prod"));
 
         assert!(!ss.satisfies_annotations(&annotations));
@@ -241,14 +241,14 @@ mod tests {
             }
         });
         let ss: SimpleSigning = serde_json::from_value(ss_json).unwrap();
-        let annotations: HashMap<String, String> = HashMap::new();
+        let annotations: BTreeMap<String, String> = BTreeMap::new();
 
         assert!(ss.satisfies_annotations(&annotations));
     }
 
     #[test]
     fn optional_has_all_the_required_annotations() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(String::from("env"), String::from("prod"));
         annotations.insert(String::from("number"), String::from("1"));
         annotations.insert(String::from("bool"), String::from("true"));
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn optional_does_not_satisfy_annotations_because_one_annotation_is_missing() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(String::from("env"), String::from("prod"));
         annotations.insert(String::from("owner"), String::from("flavio"));
 
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn optional_does_not_satisfy_annotations_because_one_annotation_has_different_value() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(String::from("env"), String::from("prod"));
         annotations.insert(String::from("owner"), String::from("flavio"));
 
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn optional_satisfies_annotations_when_no_annotation_is_provided() {
-        let annotations: HashMap<String, String> = HashMap::new();
+        let annotations: BTreeMap<String, String> = BTreeMap::new();
 
         let optional_json = json!({
             "env": "prod",

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -15,9 +15,10 @@
 
 use const_oid::ObjectIdentifier;
 use digest::Digest;
-use oci_distribution::client::ImageLayer;
+use oci_client::client::ImageLayer;
 use serde::Serialize;
-use std::{collections::HashMap, fmt};
+use std::collections::BTreeMap;
+use std::fmt;
 use tracing::{debug, info, warn};
 use x509_cert::der::DecodePem;
 use x509_cert::ext::pkix::name::GeneralName;
@@ -238,8 +239,8 @@ impl SignatureLayer {
     /// object are to be considered **trusted** and **verified**, according to
     /// the parameters provided to this method.
     pub(crate) fn new(
-        descriptor: &oci_distribution::manifest::OciDescriptor,
-        layer: &oci_distribution::client::ImageLayer,
+        descriptor: &oci_client::manifest::OciDescriptor,
+        layer: &oci_client::client::ImageLayer,
         source_image_digest: &str,
         rekor_pub_key: Option<&CosignVerificationKey>,
         fulcio_cert_pool: Option<&CertificatePool>,
@@ -289,7 +290,7 @@ impl SignatureLayer {
         })
     }
 
-    fn get_signature_from_annotations(annotations: &HashMap<String, String>) -> Result<String> {
+    fn get_signature_from_annotations(annotations: &BTreeMap<String, String>) -> Result<String> {
         let signature: String = annotations
             .get(SIGSTORE_SIGNATURE_ANNOTATION)
             .cloned()
@@ -298,7 +299,7 @@ impl SignatureLayer {
     }
 
     fn get_bundle_from_annotations(
-        annotations: &HashMap<String, String>,
+        annotations: &BTreeMap<String, String>,
         rekor_pub_key: Option<&CosignVerificationKey>,
     ) -> Result<Option<Bundle>> {
         let bundle = match annotations.get(SIGSTORE_BUNDLE_ANNOTATION) {
@@ -315,7 +316,7 @@ impl SignatureLayer {
     }
 
     fn get_certificate_signature_from_annotations(
-        annotations: &HashMap<String, String>,
+        annotations: &BTreeMap<String, String>,
         fulcio_cert_pool: Option<&CertificatePool>,
         bundle: Option<&Bundle>,
     ) -> Option<CertificateSignature> {
@@ -386,20 +387,19 @@ impl SignatureLayer {
 /// returned `SignatureLayer` is guaranteed to be
 /// verified using the given Rekor and Fulcio keys.
 pub(crate) fn build_signature_layers(
-    manifest: &oci_distribution::manifest::OciImageManifest,
+    manifest: &oci_client::manifest::OciImageManifest,
     source_image_digest: &str,
-    layers: &[oci_distribution::client::ImageLayer],
+    layers: &[oci_client::client::ImageLayer],
     rekor_pub_key: Option<&CosignVerificationKey>,
     fulcio_cert_pool: Option<&CertificatePool>,
 ) -> Result<Vec<SignatureLayer>> {
     let mut signature_layers: Vec<SignatureLayer> = Vec::new();
 
     for manifest_layer in &manifest.layers {
-        let matching_layer: Option<&oci_distribution::client::ImageLayer> =
-            layers.iter().find(|l| {
-                let tmp: ImageLayer = (*l).clone();
-                tmp.sha256_digest() == manifest_layer.digest
-            });
+        let matching_layer: Option<&oci_client::client::ImageLayer> = layers.iter().find(|l| {
+            let tmp: ImageLayer = (*l).clone();
+            tmp.sha256_digest() == manifest_layer.digest
+        });
         if let Some(layer) = matching_layer {
             match SignatureLayer::new(
                 manifest_layer,
@@ -670,11 +670,11 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn new_signature_layer_fails_because_bad_descriptor() {
-        let descriptor = oci_distribution::manifest::OciDescriptor {
+        let descriptor = oci_client::manifest::OciDescriptor {
             media_type: "not what you would expected".into(),
             ..Default::default()
         };
-        let layer = oci_distribution::client::ImageLayer {
+        let layer = oci_client::client::ImageLayer {
             media_type: super::SIGSTORE_OCI_MEDIA_TYPE.to_string(),
             data: Vec::new(),
             annotations: None,
@@ -702,11 +702,11 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn new_signature_layer_fails_because_bad_layer() {
-        let descriptor = oci_distribution::manifest::OciDescriptor {
+        let descriptor = oci_client::manifest::OciDescriptor {
             media_type: super::SIGSTORE_OCI_MEDIA_TYPE.to_string(),
             ..Default::default()
         };
-        let layer = oci_distribution::client::ImageLayer {
+        let layer = oci_client::client::ImageLayer {
             media_type: "not what you would expect".into(),
             data: Vec::new(),
             annotations: None,
@@ -734,12 +734,12 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn new_signature_layer_fails_because_checksum_mismatch() {
-        let descriptor = oci_distribution::manifest::OciDescriptor {
+        let descriptor = oci_client::manifest::OciDescriptor {
             media_type: super::SIGSTORE_OCI_MEDIA_TYPE.to_string(),
             digest: "some digest".into(),
             ..Default::default()
         };
-        let layer = oci_distribution::client::ImageLayer {
+        let layer = oci_client::client::ImageLayer {
             media_type: super::SIGSTORE_OCI_MEDIA_TYPE.to_string(),
             data: "some other contents".into(),
             annotations: None,
@@ -767,7 +767,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn get_signature_from_annotations_success() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(SIGSTORE_SIGNATURE_ANNOTATION.into(), "foo".into());
 
         let actual = SignatureLayer::get_signature_from_annotations(&annotations);
@@ -776,7 +776,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn get_signature_from_annotations_failure() {
-        let annotations: HashMap<String, String> = HashMap::new();
+        let annotations: BTreeMap<String, String> = BTreeMap::new();
 
         let actual = SignatureLayer::get_signature_from_annotations(&annotations);
         assert!(actual.is_err());
@@ -790,7 +790,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
         //
         // We care only about the only case not tested: to not
         // fail when no bundle is specified.
-        let annotations: HashMap<String, String> = HashMap::new();
+        let annotations: BTreeMap<String, String> = BTreeMap::new();
         let rekor_pub_key = get_rekor_public_key();
 
         let actual =
@@ -801,7 +801,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn get_certificate_signature_from_annotations_returns_none() {
-        let annotations: HashMap<String, String> = HashMap::new();
+        let annotations: BTreeMap<String, String> = BTreeMap::new();
         let fulcio_cert_pool = get_fulcio_cert_pool();
 
         let actual = SignatureLayer::get_certificate_signature_from_annotations(
@@ -815,7 +815,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn get_certificate_signature_from_annotations_fails_when_no_bundle_is_given() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
 
         // add a fake cert, contents are not relevant
         annotations.insert(SIGSTORE_CERT_ANNOTATION.to_string(), "a cert".to_string());
@@ -832,7 +832,7 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
 
     #[test]
     fn get_certificate_signature_from_annotations_fails_when_no_fulcio_pub_key_is_given() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
 
         // add a fake cert, contents are not relevant
         annotations.insert(SIGSTORE_CERT_ANNOTATION.to_string(), "a cert".to_string());

--- a/src/cosign/verification_constraint/annotation_verifier.rs
+++ b/src/cosign/verification_constraint/annotation_verifier.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use super::VerificationConstraint;
 use crate::cosign::signature_layers::SignatureLayer;
@@ -16,7 +16,7 @@ use crate::errors::Result;
 /// These will be simply be ignored by the verifier.
 #[derive(Default, Debug)]
 pub struct AnnotationVerifier {
-    pub annotations: HashMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
 }
 
 impl VerificationConstraint for AnnotationVerifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! use sigstore::errors::SigstoreVerifyConstraintsError;
 //!
 //! use std::boxed::Box;
-//! use std::collections::HashMap;
+//! use std::collections::BTreeMap;
 //! use std::fs;
 //!
 //! #[tokio::main]
@@ -118,7 +118,7 @@
 //!   ).await.expect("Could not obtain signature layers");
 //!
 //!   // Define verification constraints
-//!   let mut annotations: HashMap<String, String> = HashMap::new();
+//!   let mut annotations: BTreeMap<String, String> = BTreeMap::new();
 //!   annotations.insert("env".to_string(), "prod".to_string());
 //!   let annotation_verifier = AnnotationVerifier{
 //!     annotations,

--- a/src/mock_client.rs
+++ b/src/mock_client.rs
@@ -18,7 +18,7 @@ pub(crate) mod test {
     use crate::errors::{Result, SigstoreError};
 
     use async_trait::async_trait;
-    use oci_distribution::{
+    use oci_client::{
         client::{ImageData, PushResponse},
         manifest::OciManifest,
         secrets::RegistryAuth,
@@ -106,11 +106,11 @@ pub(crate) mod test {
 
         async fn push(
             &mut self,
-            image_ref: &oci_distribution::Reference,
-            _layers: &[oci_distribution::client::ImageLayer],
-            _config: oci_distribution::client::Config,
-            _auth: &oci_distribution::secrets::RegistryAuth,
-            _manifest: Option<oci_distribution::manifest::OciImageManifest>,
+            image_ref: &oci_client::Reference,
+            _layers: &[oci_client::client::ImageLayer],
+            _config: oci_client::client::Config,
+            _auth: &oci_client::secrets::RegistryAuth,
+            _manifest: Option<oci_client::manifest::OciImageManifest>,
         ) -> Result<PushResponse> {
             let mock_response =
                 self.push_response

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -30,22 +30,22 @@ pub enum Auth {
     Basic(String, String),
 }
 
-impl From<&Auth> for oci_distribution::secrets::RegistryAuth {
+impl From<&Auth> for oci_client::secrets::RegistryAuth {
     fn from(auth: &Auth) -> Self {
         match auth {
-            Auth::Anonymous => oci_distribution::secrets::RegistryAuth::Anonymous,
+            Auth::Anonymous => oci_client::secrets::RegistryAuth::Anonymous,
             Auth::Basic(username, pass) => {
-                oci_distribution::secrets::RegistryAuth::Basic(username.clone(), pass.clone())
+                oci_client::secrets::RegistryAuth::Basic(username.clone(), pass.clone())
             }
         }
     }
 }
 
-impl From<&oci_distribution::secrets::RegistryAuth> for Auth {
-    fn from(auth: &oci_distribution::secrets::RegistryAuth) -> Self {
+impl From<&oci_client::secrets::RegistryAuth> for Auth {
+    fn from(auth: &oci_client::secrets::RegistryAuth) -> Self {
         match auth {
-            oci_distribution::secrets::RegistryAuth::Anonymous => Auth::Anonymous,
-            oci_distribution::secrets::RegistryAuth::Basic(username, pass) => {
+            oci_client::secrets::RegistryAuth::Anonymous => Auth::Anonymous,
+            oci_client::secrets::RegistryAuth::Basic(username, pass) => {
                 Auth::Basic(username.clone(), pass.clone())
             }
         }
@@ -64,13 +64,13 @@ pub enum ClientProtocol {
     HttpsExcept(Vec<String>),
 }
 
-impl From<ClientProtocol> for oci_distribution::client::ClientProtocol {
+impl From<ClientProtocol> for oci_client::client::ClientProtocol {
     fn from(cp: ClientProtocol) -> Self {
         match cp {
-            ClientProtocol::Http => oci_distribution::client::ClientProtocol::Http,
-            ClientProtocol::Https => oci_distribution::client::ClientProtocol::Https,
+            ClientProtocol::Http => oci_client::client::ClientProtocol::Http,
+            ClientProtocol::Https => oci_client::client::ClientProtocol::Https,
             ClientProtocol::HttpsExcept(exceptions) => {
-                oci_distribution::client::ClientProtocol::HttpsExcept(exceptions)
+                oci_client::client::ClientProtocol::HttpsExcept(exceptions)
             }
         }
     }
@@ -85,11 +85,11 @@ pub enum CertificateEncoding {
     Pem,
 }
 
-impl From<CertificateEncoding> for oci_distribution::client::CertificateEncoding {
+impl From<CertificateEncoding> for oci_client::client::CertificateEncoding {
     fn from(ce: CertificateEncoding) -> Self {
         match ce {
-            CertificateEncoding::Der => oci_distribution::client::CertificateEncoding::Der,
-            CertificateEncoding::Pem => oci_distribution::client::CertificateEncoding::Pem,
+            CertificateEncoding::Der => oci_client::client::CertificateEncoding::Der,
+            CertificateEncoding::Pem => oci_client::client::CertificateEncoding::Pem,
         }
     }
 }
@@ -116,9 +116,9 @@ impl PartialOrd for Certificate {
     }
 }
 
-impl From<&Certificate> for oci_distribution::client::Certificate {
+impl From<&Certificate> for oci_client::client::Certificate {
     fn from(cert: &Certificate) -> Self {
-        oci_distribution::client::Certificate {
+        oci_client::client::Certificate {
             encoding: cert.encoding.clone().into(),
             data: cert.data.clone(),
         }
@@ -171,9 +171,9 @@ impl Default for ClientConfig {
     }
 }
 
-impl From<ClientConfig> for oci_distribution::client::ClientConfig {
+impl From<ClientConfig> for oci_client::client::ClientConfig {
     fn from(config: ClientConfig) -> Self {
-        oci_distribution::client::ClientConfig {
+        oci_client::client::ClientConfig {
             protocol: config.protocol.into(),
             accept_invalid_certificates: config.accept_invalid_certificates,
             #[cfg(feature = "full-native-tls")]
@@ -197,17 +197,17 @@ pub struct PushResponse {
     pub manifest_url: String,
 }
 
-impl From<PushResponse> for oci_distribution::client::PushResponse {
+impl From<PushResponse> for oci_client::client::PushResponse {
     fn from(pr: PushResponse) -> Self {
-        oci_distribution::client::PushResponse {
+        oci_client::client::PushResponse {
             config_url: pr.config_url,
             manifest_url: pr.manifest_url,
         }
     }
 }
 
-impl From<oci_distribution::client::PushResponse> for PushResponse {
-    fn from(pr: oci_distribution::client::PushResponse) -> Self {
+impl From<oci_client::client::PushResponse> for PushResponse {
+    fn from(pr: oci_client::client::PushResponse) -> Self {
         PushResponse {
             config_url: pr.config_url,
             manifest_url: pr.manifest_url,

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -157,6 +157,16 @@ pub struct ClientConfig {
     /// A list of extra root certificate to trust. This can be used to connect
     /// to servers using self-signed certificates
     pub extra_root_certificates: Vec<Certificate>,
+
+    /// Set the `HTTPS PROXY` used by the client.
+    ///
+    /// This defaults to `None`.
+    pub https_proxy: Option<String>,
+
+    /// Set the `NO PROXY` used by the client.
+    ///
+    /// This defaults to `None`.
+    pub no_proxy: Option<String>,
 }
 
 impl Default for ClientConfig {
@@ -167,6 +177,8 @@ impl Default for ClientConfig {
             accept_invalid_hostnames: false,
             accept_invalid_certificates: false,
             extra_root_certificates: Vec::new(),
+            https_proxy: None,
+            no_proxy: None,
         }
     }
 }
@@ -183,6 +195,8 @@ impl From<ClientConfig> for oci_client::client::ClientConfig {
                 .iter()
                 .map(|c| c.into())
                 .collect(),
+            https_proxy: config.https_proxy,
+            no_proxy: config.no_proxy,
             ..Default::default()
         }
     }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -35,6 +35,8 @@ use crate::errors::Result;
 
 use async_trait::async_trait;
 
+use ::oci_client as oci_client_dep;
+
 /// Workaround to ensure the `Send + Sync` supertraits are
 /// required by ClientCapabilities only when the target
 /// architecture is NOT wasm32.
@@ -61,29 +63,29 @@ pub(crate) trait ClientCapabilitiesDeps {}
 pub(crate) trait ClientCapabilities: ClientCapabilitiesDeps {
     async fn fetch_manifest_digest(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
+        image: &oci_client_dep::Reference,
+        auth: &oci_client_dep::secrets::RegistryAuth,
     ) -> Result<String>;
 
     async fn pull(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
+        image: &oci_client_dep::Reference,
+        auth: &oci_client_dep::secrets::RegistryAuth,
         accepted_media_types: Vec<&str>,
-    ) -> Result<oci_distribution::client::ImageData>;
+    ) -> Result<oci_client_dep::client::ImageData>;
 
     async fn pull_manifest(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
-    ) -> Result<(oci_distribution::manifest::OciManifest, String)>;
+        image: &oci_client_dep::Reference,
+        auth: &oci_client_dep::secrets::RegistryAuth,
+    ) -> Result<(oci_client_dep::manifest::OciManifest, String)>;
 
     async fn push(
         &mut self,
-        image_ref: &oci_distribution::Reference,
-        layers: &[oci_distribution::client::ImageLayer],
-        config: oci_distribution::client::Config,
-        auth: &oci_distribution::secrets::RegistryAuth,
-        manifest: Option<oci_distribution::manifest::OciImageManifest>,
-    ) -> Result<oci_distribution::client::PushResponse>;
+        image_ref: &oci_client_dep::Reference,
+        layers: &[oci_client_dep::client::ImageLayer],
+        config: oci_client_dep::client::Config,
+        auth: &oci_client_dep::secrets::RegistryAuth,
+        manifest: Option<oci_client_dep::manifest::OciImageManifest>,
+    ) -> Result<oci_client_dep::client::PushResponse>;
 }

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 /// For testing purposes, use instead the client inside of the
 /// `mock_client` module.
 pub(crate) struct OciClient {
-    pub registry_client: oci_distribution::Client,
+    pub registry_client: oci_client::Client,
 }
 
 impl ClientCapabilitiesDeps for OciClient {}
@@ -34,8 +34,8 @@ impl ClientCapabilitiesDeps for OciClient {}
 impl ClientCapabilities for OciClient {
     async fn fetch_manifest_digest(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
+        image: &oci_client::Reference,
+        auth: &oci_client::secrets::RegistryAuth,
     ) -> Result<String> {
         self.registry_client
             .fetch_manifest_digest(image, auth)
@@ -48,10 +48,10 @@ impl ClientCapabilities for OciClient {
 
     async fn pull(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
+        image: &oci_client::Reference,
+        auth: &oci_client::secrets::RegistryAuth,
         accepted_media_types: Vec<&str>,
-    ) -> Result<oci_distribution::client::ImageData> {
+    ) -> Result<oci_client::client::ImageData> {
         self.registry_client
             .pull(image, auth, accepted_media_types)
             .await
@@ -63,9 +63,9 @@ impl ClientCapabilities for OciClient {
 
     async fn pull_manifest(
         &mut self,
-        image: &oci_distribution::Reference,
-        auth: &oci_distribution::secrets::RegistryAuth,
-    ) -> Result<(oci_distribution::manifest::OciManifest, String)> {
+        image: &oci_client::Reference,
+        auth: &oci_client::secrets::RegistryAuth,
+    ) -> Result<(oci_client::manifest::OciManifest, String)> {
         self.registry_client
             .pull_manifest(image, auth)
             .await
@@ -77,12 +77,12 @@ impl ClientCapabilities for OciClient {
 
     async fn push(
         &mut self,
-        image_ref: &oci_distribution::Reference,
-        layers: &[oci_distribution::client::ImageLayer],
-        config: oci_distribution::client::Config,
-        auth: &oci_distribution::secrets::RegistryAuth,
-        manifest: Option<oci_distribution::manifest::OciImageManifest>,
-    ) -> Result<oci_distribution::client::PushResponse> {
+        image_ref: &oci_client::Reference,
+        layers: &[oci_client::client::ImageLayer],
+        config: oci_client::client::Config,
+        auth: &oci_client::secrets::RegistryAuth,
+        manifest: Option<oci_client::manifest::OciImageManifest>,
+    ) -> Result<oci_client::client::PushResponse> {
         self.registry_client
             .push(image_ref, layers, config, auth, manifest)
             .await

--- a/src/registry/oci_reference.rs
+++ b/src/registry/oci_reference.rs
@@ -20,14 +20,14 @@ use std::str::FromStr;
 /// `OciReference` provides a general type to represent any way of referencing images within an OCI registry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OciReference {
-    pub(crate) oci_reference: oci_distribution::Reference,
+    pub(crate) oci_reference: oci_client::Reference,
 }
 
 impl FromStr for OciReference {
     type Err = SigstoreError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<oci_distribution::Reference>()
+        s.parse::<oci_client::Reference>()
             .map_err(|_| SigstoreError::OciReferenceNotValidError {
                 reference: s.to_string(),
             })
@@ -39,14 +39,14 @@ impl OciReference {
     /// Create a Reference with a registry, repository and tag.
     pub fn with_tag(registry: String, repository: String, tag: String) -> Self {
         OciReference {
-            oci_reference: oci_distribution::Reference::with_tag(registry, repository, tag),
+            oci_reference: oci_client::Reference::with_tag(registry, repository, tag),
         }
     }
 
     /// Create a Reference with a registry, repository and digest.
     pub fn with_digest(registry: String, repository: String, digest: String) -> Self {
         OciReference {
-            oci_reference: oci_distribution::Reference::with_digest(registry, repository, digest),
+            oci_reference: oci_client::Reference::with_digest(registry, repository, digest),
         }
     }
 


### PR DESCRIPTION
~~This is still in draft. We will wait for a new release of `oci-client` to include https://github.com/oras-project/rust-oci-client/pull/160~~

#### Summary

In some special cases, client needs to connect a proxy to pull signature via a proxy. This PR mainly accomplishes this.

#### Release Note

* Config changes: Add proxy related items to `ClientConfig`
* Dep changes: update `oci-distribution` to `oci-client`


#### Documentation

TODO