### PR TITLE
Simplify cosign verify-bundle example

### DIFF
--- a/examples/cosign/verify-bundle/README.md
+++ b/examples/cosign/verify-bundle/README.md
@@ -1,15 +1,10 @@
 This example shows how to verify a blob, using a bundle that was created by the
 `cosign sign-blob` command.
 
-### Create the artifact to be signed.
-```console
+### Sign README.md file using cosign
+```
 cd examples/cosign/verify-bundle
-echo something > artifact.txt
-```
-
-### Sign the artifact.txt file using cosign
-```
-cosign sign-blob --bundle=artifact.bundle artifact.txt
+cosign sign-blob --bundle=artifact.bundle README.md
 ```
 
 ### Verify using sigstore-rs:
@@ -17,5 +12,5 @@ cosign sign-blob --bundle=artifact.bundle artifact.txt
 cargo run --example verify-bundle -- \
     --rekor-pub-key ~/.sigstore/root/targets/rekor.pub \
     --bundle artifact.bundle \
-    artifact.txt
+    README.md
 ```

--- a/examples/cosign/verify-bundle/run.sh
+++ b/examples/cosign/verify-bundle/run.sh
@@ -1,14 +1,8 @@
-BLOB="artifact.txt"
+BLOB="README.md"
 BUNDLE="artifact.bundle"
 
-echo -e "\nGenerate the blob to be signed"
-echo something > $BLOB
-
-echo -e "\nSign the artifact.txt file using sign-blob"
-COSIGN_EXPERIMENTAL=1 cosign sign-blob --bundle=$BUNDLE $BLOB
-
-echo -e "\nVerify using cosign. TODO: remove this later"
-cosign verify-blob --bundle=$BUNDLE $BLOB
+echo -e "\nSign README.md file using sign-blob"
+cosign sign-blob --bundle=$BUNDLE $BLOB
 
 echo -e "\nRun examples/cosign/verify-bundle"
 cargo run --example verify-bundle -- \


### PR DESCRIPTION
* Remove unneeded env var
* Use the README as the blob
* Avoid running sigstore/cosign to verify: the sigstore-rs example should be enough

Partially fixes #242: this is the last instance of COSIGN_EXPERIMENTAL but I don't think I've tested every single example yet so not sure if this is completely fixed or not... 