### PR TITLE
cosign: fix regex dependency import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ sigstore-trust-root = [
   "futures-util",
   "tough",
   "reqwest_0_11",
-  "regex",
   "tokio/sync",
 ]
 sigstore-trust-root-native-tls = [
@@ -78,7 +77,7 @@ cosign-rustls-tls = [
   "cosign",
   "registry-rustls-tls",
 ]
-cosign = ["olpc-cjson"]
+cosign = ["olpc-cjson", "regex"]
 cert = []
 
 registry-native-tls = ["oci-client/native-tls", "registry"]


### PR DESCRIPTION
This is a bug fix PR. `regex` dependency is only used in cosign module now. Before this commit, when we only enable `cosign-rustls-tls` feature, the compilation will fail because regex dependency is not enabled.
