### PR TITLE
Deprecate actions-rs actions

### DIFF
--- a/.github/workflows/auto-publish-crates-upon-release.yml
+++ b/.github/workflows/auto-publish-crates-upon-release.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -  uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      -  uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-         with:
-           toolchain: stable
-           override: true
+      - name: Rustup
+        run: |
+          rustup install stable
+          rustup override set stable
 
       - name: publish crates
         run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,15 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: build
-          args: --manifest-path=tests/conformance/Cargo.toml
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+      - run: |
+          cargo build --manifest-path=tests/conformance/Cargo.toml
       - uses: sigstore/sigstore-conformance@main
         with:
           entrypoint: ${{ github.workspace }}/tests/conformance/target/debug/sigstore

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,6 +11,7 @@ jobs:
         run: |
           rustup install --profile minimal stable
           rustup override set stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo build --manifest-path=tests/conformance/Cargo.toml
       - uses: sigstore/sigstore-conformance@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
         run: |
           rustup install --profile minimal stable
           rustup override set stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo check
 
@@ -25,6 +26,7 @@ jobs:
           rustup install --profile minimal stable
           rustup override set stable
           rustup target add wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo check --no-default-features --features wasm
 
@@ -37,6 +39,7 @@ jobs:
         run: |
           rustup install --profile minimal stable
           rustup override set stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo test --workspace --features full-native-tls,test-registry
 
@@ -49,6 +52,7 @@ jobs:
         run: |
           rustup install --profile minimal nightly
           rustup override set nightly
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           make doc
 
@@ -62,6 +66,7 @@ jobs:
           rustup install --profile minimal stable
           rustup override set stable
           rustup component add rustfmt
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo fmt --all -- --check
 
@@ -75,5 +80,6 @@ jobs:
           rustup install --profile minimal stable
           rustup override set stable
           rustup component add clippy
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       - run: |
           cargo clippy --workspace -- -D warnings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,56 +8,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: check
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+      - run: |
+          cargo check
 
   check-wasm:
     name: Check WASM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: check
-          args: --no-default-features --features wasm
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+          rustup target add wasm32-unknown-unknown
+      - run: |
+          cargo check --no-default-features --features wasm
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: test
-          args: --workspace --features full-native-tls,test-registry
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+      - run: |
+          cargo test --workspace --features full-native-tls,test-registry
 
   doc:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - name: Rustup (nightly)
+        run: |
+          rustup install --profile minimal nightly
+          rustup override set nightly
       - run: |
           make doc
 
@@ -66,29 +57,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+          rustup component add rustfmt
+      - run: |
+          cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+      - name: Rustup
+        run: |
+          rustup install --profile minimal stable
+          rustup override set stable
+          rustup component add clippy
+      - run: |
+          cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
`actions-rs` actions are unmaintained and archived, we should not be using them. Luckily we weren't really using anything special from them: using `rustup`(that is part of the GitHub image) and `cargo` directly should give us the same results
* Use rustup and cargo instead of specific actions
* Use `Swatinem/rust-cache` to speed up builds

The second part is of course optional. I added it since
* it does speed things up: CI is 1 min faster on wall clock and 4-5 mins faster in job duration
* doing the same thing without a 3rd party action likely leads to annoying debug situations later (rust-cache key calculation seems quite extensive)