### PR TITLE
chore(deps): upgrade openidconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,17 +53,11 @@ sigstore-trust-root = [
   "sigstore_protobuf_specs",
   "futures-util",
   "tough",
-  "reqwest_0_11",
+  "reqwest",
   "tokio/sync",
 ]
-sigstore-trust-root-native-tls = [
-  "reqwest_0_11/native-tls",
-  "sigstore-trust-root",
-]
-sigstore-trust-root-rustls-tls = [
-  "reqwest_0_11/rustls-tls",
-  "sigstore-trust-root",
-]
+sigstore-trust-root-native-tls = ["reqwest/native-tls", "sigstore-trust-root"]
+sigstore-trust-root-rustls-tls = ["reqwest/rustls-tls", "sigstore-trust-root"]
 
 cosign-native-tls = [
   "oci-client/native-tls",
@@ -110,8 +104,9 @@ futures-util = { version = "0.3", optional = true }
 lazy_static = "1.5"
 oci-client = { default-features = false, optional = true, version = "0.14" }
 olpc-cjson = { version = "0.1", optional = true }
-openidconnect = { version = "3.5", default-features = false, features = [
+openidconnect = { version = "4.0", default-features = false, features = [
   "reqwest",
+  "reqwest-blocking",
 ], optional = true }
 p256 = "0.13"
 p384 = "0.13"
@@ -126,11 +121,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "multipart",
 ], optional = true }
-# We have to include this old version of reqwest because tough is currently using it.
-# By including it, we can configure which TLS backend it's going to use, otherwise fetching the
-# TUF sigstore repository will fail at runtime because the old version of reqwest
-# will be compiled withtout TLS support.
-reqwest_0_11 = { package = "reqwest", version = "0.11", default-features = false, optional = true }
 rsa = "0.9"
 scrypt = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -202,6 +202,10 @@ pub enum SigstoreError {
     #[error("Verification of OIDC claims received from OpenIdProvider failed")]
     ClaimsVerificationError,
 
+    #[cfg(feature = "oauth")]
+    #[error("Claims configuration error: {0}")]
+    ClaimsConfigurationError(#[from] openidconnect::ConfigurationError),
+
     #[error("Failed to access token endpoint")]
     ClaimsAccessPointError,
 

--- a/src/oauth/openidflow.rs
+++ b/src/oauth/openidflow.rs
@@ -80,25 +80,32 @@
 //! ```
 //! This of course has a performance hit when used inside of an async function.
 
-use crate::errors::{Result, SigstoreError};
-use tracing::error;
-
-use openidconnect::core::{
-    CoreClient, CoreIdToken, CoreIdTokenClaims, CoreIdTokenVerifier, CoreProviderMetadata,
-    CoreResponseType, CoreTokenResponse,
+use std::{
+    io::{BufRead, BufReader, Write},
+    net::TcpListener,
 };
-use openidconnect::reqwest::async_http_client;
+
 use openidconnect::{
-    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce,
+    core::{
+        CoreAuthenticationFlow, CoreClient, CoreIdToken, CoreIdTokenClaims, CoreIdTokenVerifier,
+        CoreProviderMetadata, CoreTokenResponse,
+    },
+    reqwest, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce,
     PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
 };
-
-#[cfg(not(target_arch = "wasm32"))]
-use openidconnect::reqwest::http_client;
-
-use std::io::{BufRead, BufReader, Write};
-use std::net::TcpListener;
+use tracing::error;
 use url::Url;
+
+use crate::errors::{Result, SigstoreError};
+
+pub(crate) type OpenIdClient = openidconnect::core::CoreClient<
+    openidconnect::EndpointSet,      // HasAuthUrl
+    openidconnect::EndpointNotSet,   // HasDeviceAuthUrl
+    openidconnect::EndpointNotSet,   // HasIntrospectionUrl
+    openidconnect::EndpointNotSet,   // HasRevocationUrl
+    openidconnect::EndpointMaybeSet, // HasTokenUrl
+    openidconnect::EndpointMaybeSet, // HasUserInfoUrl
+>;
 
 #[derive(Debug)]
 pub struct OpenIDAuthorize {
@@ -136,7 +143,7 @@ impl OpenIDAuthorize {
     fn auth_url_internal(
         &self,
         provider_metadata: CoreProviderMetadata,
-    ) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    ) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
         let client_id = ClientId::new(self.oidc_cliend_id.to_owned());
         let client_secret = ClientSecret::new(self.oidc_client_secret.to_owned());
 
@@ -150,7 +157,7 @@ impl OpenIDAuthorize {
 
         let (authorize_url, _, nonce) = client
             .authorize_url(
-                AuthenticationFlow::<CoreResponseType>::AuthorizationCode,
+                CoreAuthenticationFlow::AuthorizationCode,
                 CsrfToken::new_random,
                 Nonce::new_random,
             )
@@ -161,11 +168,16 @@ impl OpenIDAuthorize {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn auth_url(&self) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    pub fn auth_url(&self) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
+        let http_client = reqwest::blocking::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let issuer = IssuerUrl::new(self.oidc_issuer.to_owned()).expect("Missing the OIDC_ISSUER.");
 
         let provider_metadata =
-            CoreProviderMetadata::discover(&issuer, http_client).map_err(|err| {
+            CoreProviderMetadata::discover(&issuer, &http_client).map_err(|err| {
                 error!("Error is: {:?}", err);
                 SigstoreError::ClaimsVerificationError
             })?;
@@ -173,10 +185,15 @@ impl OpenIDAuthorize {
         self.auth_url_internal(provider_metadata)
     }
 
-    pub async fn auth_url_async(&self) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    pub async fn auth_url_async(&self) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
+        let async_http_client = reqwest::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let issuer = IssuerUrl::new(self.oidc_issuer.to_owned()).expect("Missing the OIDC_ISSUER.");
 
-        let provider_metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+        let provider_metadata = CoreProviderMetadata::discover_async(issuer, &async_http_client)
             .await
             .map_err(|_| SigstoreError::ClaimsVerificationError)?;
 
@@ -186,7 +203,7 @@ impl OpenIDAuthorize {
 
 pub struct RedirectListener {
     client_redirect_host: String,
-    client: CoreClient,
+    client: OpenIdClient,
     nonce: Nonce,
     pkce_verifier: PkceCodeVerifier,
 }
@@ -209,7 +226,7 @@ impl RedirectListener {
     //! ```
     pub fn new(
         client_redirect_host: &str,
-        client: CoreClient,
+        client: OpenIdClient,
         nonce: Nonce,
         pkce_verifier: PkceCodeVerifier,
     ) -> Self {
@@ -274,13 +291,19 @@ impl RedirectListener {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn redirect_listener(self) -> Result<(CoreIdTokenClaims, CoreIdToken)> {
+        use openidconnect::reqwest::blocking::ClientBuilder;
+        let http_client = ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let code = self.redirect_listener_internal()?;
 
         let token_response = self
             .client
-            .exchange_code(code)
+            .exchange_code(code)?
             .set_pkce_verifier(self.pkce_verifier)
-            .request(http_client)
+            .request(&http_client)
             .map_err(|_| SigstoreError::ClaimsAccessPointError)?;
 
         Self::extract_token_and_claims(
@@ -291,13 +314,19 @@ impl RedirectListener {
     }
 
     pub async fn redirect_listener_async(self) -> Result<(CoreIdTokenClaims, CoreIdToken)> {
+        use openidconnect::reqwest::ClientBuilder;
+        let async_http_client = ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let code = self.redirect_listener_internal()?;
 
         let token_response = self
             .client
-            .exchange_code(code)
+            .exchange_code(code)?
             .set_pkce_verifier(self.pkce_verifier)
-            .request_async(async_http_client)
+            .request_async(&async_http_client)
             .await
             .map_err(|_| SigstoreError::ClaimsAccessPointError)?;
 


### PR DESCRIPTION
Upgrade openidconnect to latest version. This is a major version change, which caused quite some breakage. The code has been fixed to build and all the tests are passing.

This upgrade allows us to drop the dependency on the really old 0.11 reqwest package.

This supersedes https://github.com/sigstore/sigstore-rs/pull/428

