### PR TITLE
oci-client: allow using native cert store with rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ sigstore-trust-root = [
 sigstore-trust-root-native-tls = ["reqwest/native-tls", "sigstore-trust-root"]
 sigstore-trust-root-rustls-tls = ["reqwest/rustls-tls", "sigstore-trust-root"]
 
+# This feature flag is used to allow using the platform's native certificate store
+# when using rustls suites
+rustls-tls-native-roots = ["oci-client/rustls-tls-native-roots"]
+
 cosign-native-tls = [
   "oci-client/native-tls",
   "cert",


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Add support for platform's certs store when using rustls
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->



#### Release Note
Adds a new feature `rustls-tls-native-roots`
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation

The feature `rustls-tls-native-roots` allows the client to read platform's native certificate store when using rustls suites.

This useful when self-signed registry is used and the certs are loaded in the platform's trusted CA by commands like update-ca-certificates.

<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
