### PR TITLE
build(deps): rustls webpki 0.103

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ url = "2.5"
 x509-cert = { version = "0.2", features = ["builder", "pem", "std", "sct"] }
 crypto_secretbox = "0.1"
 zeroize = "1.8"
-rustls-webpki = { version = "0.103", features = ["alloc"] }
+rustls-webpki = { version = "0.103", features = ["alloc", "ring"] }
 pki-types = { package = "rustls-pki-types", version = "1.11", default-features = false }
 serde_repr = "0.1"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ x509-cert = { version = "0.2", features = ["builder", "pem", "std", "sct"] }
 crypto_secretbox = "0.1"
 zeroize = "1.8"
 rustls-webpki = { version = "0.103", features = ["alloc"] }
+pki-types = { package = "rustls-pki-types", version = "1.11", default-features = false }
 serde_repr = "0.1"
 hex = "0.4"
 json-syntax = { version = "0.12", features = ["canonicalize", "serde"] }

--- a/src/bundle/verify/verifier.rs
+++ b/src/bundle/verify/verifier.rs
@@ -16,10 +16,10 @@
 
 use std::io::{self, Read};
 
+use pki_types::{CertificateDer, UnixTime};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::debug;
-use webpki::types::{CertificateDer, UnixTime};
 use x509_cert::der::Encode;
 
 use crate::{

--- a/src/cosign/client_builder.rs
+++ b/src/cosign/client_builder.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use pki_types::CertificateDer;
 use tracing::info;
-use webpki::types::CertificateDer;
 
 use super::client::Client;
 use crate::crypto::SigningScheme;

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -281,8 +281,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use pki_types::CertificateDer;
     use serde_json::json;
-    use webpki::types::CertificateDer;
 
     use super::constraint::{AnnotationMarker, PrivateKeySigner};
     use super::verification_constraint::cert_subject_email_verifier::StringVerifier;

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -435,7 +435,7 @@ impl CertificateSignature {
         // ensure the certificate has been issued by Fulcio
         fulcio_cert_pool.verify_pem_cert(
             cert_pem,
-            Some(webpki::types::UnixTime::since_unix_epoch(
+            Some(pki_types::UnixTime::since_unix_epoch(
                 cert.tbs_certificate.validity.not_before.to_unix_duration(),
             )),
         )?;

--- a/src/cosign/verification_constraint/certificate_verifier.rs
+++ b/src/cosign/verification_constraint/certificate_verifier.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use pkcs8::der::Decode;
+use pki_types::CertificateDer;
 use tracing::warn;
-use webpki::types::CertificateDer;
 use x509_cert::Certificate;
 
 use super::VerificationConstraint;

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -14,10 +14,8 @@
 // limitations under the License.
 
 use const_oid::db::rfc5280::ID_KP_CODE_SIGNING;
-use webpki::{
-    types::{CertificateDer, TrustAnchor, UnixTime},
-    EndEntityCert, KeyUsage, VerifiedPath,
-};
+use pki_types::{CertificateDer, TrustAnchor, UnixTime};
+use webpki::{EndEntityCert, KeyUsage, VerifiedPath};
 
 use crate::errors::{Result as SigstoreResult, SigstoreError};
 

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -15,9 +15,9 @@
 
 //! Set of structs and enums used to define how to interact with OCI registries
 
+use pki_types::CertificateDer;
 use serde::Serialize;
 use std::cmp::Ordering;
-use webpki::types::CertificateDer;
 
 use crate::errors;
 

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use webpki::types::CertificateDer;
+use pki_types::CertificateDer;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "sigstore-trust-root")))]
 #[cfg(feature = "sigstore-trust-root")]

--- a/src/trust/sigstore/mod.rs
+++ b/src/trust/sigstore/mod.rs
@@ -25,13 +25,13 @@ use sha2::{Digest, Sha256};
 use std::path::Path;
 use tokio_util::bytes::BytesMut;
 
+use pki_types::CertificateDer;
 use sigstore_protobuf_specs::dev::sigstore::{
     common::v1::TimeRange,
     trustroot::v1::{CertificateAuthority, TransparencyLogInstance, TrustedRoot},
 };
 use tough::TargetName;
 use tracing::debug;
-use webpki::types::CertificateDer;
 
 mod constants;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR resolves the Rustls webpki update issue, which was failing due to a breaking change. Webpki no longer exports `pki-types`, so an explicit `pki-types` dependency was added.  

Reference: https://github.com/rustls/webpki/pull/313

It also adds the `ring` feature, which is now needed because of [this breaking change](https://github.com/rustls/webpki/pull/302). 
