### PR TITLE
fix cargo clippy issues (overindentation)

### DIFF
--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -229,7 +229,7 @@ impl SignatureLayer {
     ///     with the Sigstore object
     ///   * `layer`: the data referenced by the descriptor
     ///   * `source_image_digest`: the digest of the object that we're trying
-    ///      to verify. This is **not** the digest of the signature itself.
+    ///     to verify. This is **not** the digest of the signature itself.
     ///   * `rekor_pub_key`: the public key of Rekor, used to verify `bundle`
     ///     entries
     ///   * `fulcio_pub_key`: the public key provided by Fulcio's certificate.

--- a/src/cosign/verification_constraint/certificate_verifier.rs
+++ b/src/cosign/verification_constraint/certificate_verifier.rs
@@ -23,10 +23,10 @@ impl CertificateVerifier {
     ///
     /// * `cert_bytes`: PEM encoded certificate
     /// * `require_rekor_bundle`: require the  signature layer to have a Rekor
-    ///    bundle. Having a Rekor bundle allows further checks to be performed,
-    ///    like ensuring the signature has been produced during the validity
-    ///    time frame of the certificate. It is recommended to set this value
-    ///    to `true` to have a more secure verification process.
+    ///   bundle. Having a Rekor bundle allows further checks to be performed,
+    ///   like ensuring the signature has been produced during the validity
+    ///   time frame of the certificate. It is recommended to set this value
+    ///   to `true` to have a more secure verification process.
     /// * `cert_chain`: the certificate chain that is used to verify the provided
     ///   certificate. When not specified, the certificate is assumed to be trusted
     pub fn from_pem(
@@ -43,10 +43,10 @@ impl CertificateVerifier {
     ///
     /// * `cert_bytes`: DER encoded certificate
     /// * `require_rekor_bundle`: require the  signature layer to have a Rekor
-    ///    bundle. Having a Rekor bundle allows further checks to be performed,
-    ///    like ensuring the signature has been produced during the validity
-    ///    time frame of the certificate. It is recommended to set this value
-    ///    to `true` to have a more secure verification process.
+    ///   bundle. Having a Rekor bundle allows further checks to be performed,
+    ///   like ensuring the signature has been produced during the validity
+    ///   time frame of the certificate. It is recommended to set this value
+    ///   to `true` to have a more secure verification process.
     /// * `cert_chain`: the certificate chain that is used to verify the provided
     ///   certificate. When not specified, the certificate is assumed to be trusted
     pub fn from_der(

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -24,27 +24,27 @@ pub use verification_key::CosignVerificationKey;
 
 /// Different digital signature algorithms.
 /// * `RSA_PSS_SHA256`: RSA PSS padding using SHA-256
-///    for RSA signatures. All the `usize` member inside
-///    an RSA enum represents the key size of the RSA key.
+///   for RSA signatures. All the `usize` member inside
+///   an RSA enum represents the key size of the RSA key.
 /// * `RSA_PSS_SHA384`: RSA PSS padding using SHA-384
-///    for RSA signatures.
+///   for RSA signatures.
 /// * `RSA_PSS_SHA512`: RSA PSS padding using SHA-512
-///    for RSA signatures.
+///   for RSA signatures.
 /// * `RSA_PKCS1_SHA256`: PKCS#1 1.5 padding using
-///    SHA-256 for RSA signatures.
+///   SHA-256 for RSA signatures.
 /// * `RSA_PKCS1_SHA384`: PKCS#1 1.5 padding using
-///    SHA-384 for RSA signatures.
+///   SHA-384 for RSA signatures.
 /// * `RSA_PKCS1_SHA512`: PKCS#1 1.5 padding using
-///    SHA-512 for RSA signatures.
+///   SHA-512 for RSA signatures.
 /// * `ECDSA_P256_SHA256_ASN1`: ASN.1 DER-encoded ECDSA
-///    signatures using the P-256 curve and SHA-256. It
-///    is the default signing scheme.
+///   signatures using the P-256 curve and SHA-256. It
+///   is the default signing scheme.
 /// * `ECDSA_P384_SHA384_ASN1`: ASN.1 DER-encoded ECDSA
-///    signatures using the P-384 curve and SHA-384.
+///   signatures using the P-384 curve and SHA-384.
 /// * `ED25519`: ECDSA signature using SHA2-512
-///    as the digest function and curve edwards25519. The
-///    signature format please refer
-///    to [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032.html#section-5.1.6).
+///   as the digest function and curve edwards25519. The
+///   signature format please refer
+///   to [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032.html#section-5.1.6).
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SigningScheme {


### PR DESCRIPTION
#### Summary
Fix the issues flagged by clippy which prevent a local execution of `make test` (errors from the trunk code in [gist](https://gist.github.com/dmitris/a0ce8f38352016b1b0f7441a7cec4ea9)) - namely, due to the "overindentation", incorrect alignment of the text in Markdown lists ([#doc_lazy_continuation](https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation)).

An [example](https://github.com/sigstore/sigstore-rs/actions/runs/14739461994/job/41373616982?pr=457) of the trunk code (with minor README modification) failing in CI due to the clippy issues: 

#### Release Note
NONE

#### Documentation
N/A.  

Maybe it would be good to mention that you need to install [taplo](https://taplo.tamasfe.dev/cli/installation/binary.html) and how to do it?  (Or do we want to leave it as an "initiation exercise" for the developers / prospective contributors? 😄 )
