### PR TITLE
update flag with double-dash

### DIFF
--- a/examples/cosign/verify/README.md
+++ b/examples/cosign/verify/README.md
@@ -17,7 +17,7 @@ cosign generate-key-pair
 Sign a container image:
 
 ```console
-cosign sign -key cosign.key registry-testing.svc.lan/busybox
+cosign sign --key cosign.key registry-testing.svc.lan/busybox
 ```
 
 Verify the image signature using the example program defined in

--- a/src/cosign/verification_constraint/cert_subject_email_verifier.rs
+++ b/src/cosign/verification_constraint/cert_subject_email_verifier.rs
@@ -120,7 +120,7 @@ impl Debug for CertSubjectEmailVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut issuer_str = String::new();
         if let Some(issuer) = &self.issuer {
-            issuer_str.push_str(&format!(" and {}", issuer));
+            issuer_str.push_str(&format!(" and {issuer}"));
         }
         f.write_fmt(format_args!(
             "email {}{}",
@@ -147,10 +147,8 @@ impl StringVerifier {
 impl std::fmt::Display for StringVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StringVerifier::ExactMatch(s) => f.write_fmt(format_args!("is exactly {}", s)),
-            StringVerifier::Regex(r) => {
-                f.write_fmt(format_args!("matches regular expression {}", r))
-            }
+            StringVerifier::ExactMatch(s) => f.write_fmt(format_args!("is exactly {s}")),
+            StringVerifier::Regex(r) => f.write_fmt(format_args!("matches regular expression {r}")),
         }
     }
 }

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -114,8 +114,7 @@ impl TryFrom<&SubjectPublicKeyInfoOwned> for CosignVerificationKey {
                 ed25519_dalek::VerifyingKey::try_from(subject_pub_key_info.owned_to_ref())?,
             )),
             _ => Err(SigstoreError::PublicKeyUnsupportedAlgorithmError(format!(
-                "Key with algorithm OID {} is not supported",
-                algorithm
+                "Key with algorithm OID {algorithm} is not supported"
             ))),
         }
     }


### PR DESCRIPTION
#### Summary
The current command generates a warning (below), PR changes to the standard `--key` flag.

```sh
$ cosign sign -key cosign.key registry-testing.svc.lan/busybox
WARNING: the -key flag is deprecated and will be removed in a future release. Please use the --key flag instead.
```

#### Release Note
NONE

#### Documentation
N/A
