### PR TITLE
update flag with double-dash (PR474 redux), address 'cargo clippy' issues

### DIFF
--- a/examples/cosign/verify/README.md
+++ b/examples/cosign/verify/README.md
@@ -17,7 +17,7 @@ cosign generate-key-pair
 Sign a container image:
 
 ```console
-cosign sign -key cosign.key registry-testing.svc.lan/busybox
+cosign sign --key cosign.key registry-testing.svc.lan/busybox
 ```
 
 Verify the image signature using the example program defined in

--- a/src/bundle/sign.rs
+++ b/src/bundle/sign.rs
@@ -306,7 +306,10 @@ impl SigningContext {
     }
 
     /// Configures and returns a [`SigningSession`] with the held context.
-    pub async fn signer(&self, identity_token: IdentityToken) -> SigstoreResult<SigningSession> {
+    pub async fn signer(
+        &self,
+        identity_token: IdentityToken,
+    ) -> SigstoreResult<SigningSession<'_>> {
         SigningSession::new(self, identity_token).await
     }
 
@@ -316,7 +319,7 @@ impl SigningContext {
     pub fn blocking_signer(
         &self,
         identity_token: IdentityToken,
-    ) -> SigstoreResult<blocking::SigningSession> {
+    ) -> SigstoreResult<blocking::SigningSession<'_>> {
         blocking::SigningSession::new(self, identity_token)
     }
 }

--- a/src/cosign/verification_constraint/cert_subject_email_verifier.rs
+++ b/src/cosign/verification_constraint/cert_subject_email_verifier.rs
@@ -120,7 +120,7 @@ impl Debug for CertSubjectEmailVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut issuer_str = String::new();
         if let Some(issuer) = &self.issuer {
-            issuer_str.push_str(&format!(" and {}", issuer));
+            issuer_str.push_str(&format!(" and {issuer}"));
         }
         f.write_fmt(format_args!(
             "email {}{}",
@@ -147,10 +147,8 @@ impl StringVerifier {
 impl std::fmt::Display for StringVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StringVerifier::ExactMatch(s) => f.write_fmt(format_args!("is exactly {}", s)),
-            StringVerifier::Regex(r) => {
-                f.write_fmt(format_args!("matches regular expression {}", r))
-            }
+            StringVerifier::ExactMatch(s) => f.write_fmt(format_args!("is exactly {s}")),
+            StringVerifier::Regex(r) => f.write_fmt(format_args!("matches regular expression {r}")),
         }
     }
 }

--- a/src/crypto/verification_key.rs
+++ b/src/crypto/verification_key.rs
@@ -114,8 +114,7 @@ impl TryFrom<&SubjectPublicKeyInfoOwned> for CosignVerificationKey {
                 ed25519_dalek::VerifyingKey::try_from(subject_pub_key_info.owned_to_ref())?,
             )),
             _ => Err(SigstoreError::PublicKeyUnsupportedAlgorithmError(format!(
-                "Key with algorithm OID {} is not supported",
-                algorithm
+                "Key with algorithm OID {algorithm} is not supported"
             ))),
         }
     }

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -21,7 +21,7 @@ pub mod sigstore;
 
 /// A `TrustRoot` owns all key material necessary for establishing a root of trust.
 pub trait TrustRoot {
-    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>>;
+    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer<'_>>>;
     fn rekor_keys(&self) -> crate::errors::Result<Vec<&[u8]>>;
     fn ctfe_keys(&self) -> crate::errors::Result<Vec<&[u8]>>;
 }
@@ -36,7 +36,7 @@ pub struct ManualTrustRoot<'a> {
 }
 
 impl TrustRoot for ManualTrustRoot<'_> {
-    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer>> {
+    fn fulcio_certs(&self) -> crate::errors::Result<Vec<CertificateDer<'_>>> {
         Ok(self.fulcio_certs.clone())
     }
 

--- a/src/trust/sigstore/mod.rs
+++ b/src/trust/sigstore/mod.rs
@@ -162,7 +162,7 @@ impl crate::trust::TrustRoot for SigstoreTrustRoot {
     /// the local cache if its contents are not outdated.
     ///
     /// The contents of the local cache are updated when they are outdated.
-    fn fulcio_certs(&self) -> Result<Vec<CertificateDer>> {
+    fn fulcio_certs(&self) -> Result<Vec<CertificateDer<'_>>> {
         // Allow expired certificates: they may have been active when the
         // certificate was used to sign.
         let certs = Self::ca_keys(&self.trusted_root.certificate_authorities, true);


### PR DESCRIPTION
#### Summary
#### Summary
The current command generates a warning (below), PR changes to the standard `--key` flag.

```sh
$ cosign sign -key cosign.key registry-testing.svc.lan/busybox
WARNING: the -key flag is deprecated and will be removed in a future release. Please use the --key flag instead.
```

Additionally, the change fixes some clippy issues.  `cargo clippy` output is clean with `1.88.0`.  PR also fixes `cargo +nightly clippy`  issue recorded in the [gist](https://gist.github.com/dmitris/070c05587b8be4fe0189edb5bd73c697).

The PR is an extended replica of https://github.com/sigstore/sigstore-rs/pull/474 (recreated for approval-technical reasons).

#### Release Note
NONE

#### Documentation
N/A


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
