### PR TITLE
ci: update cargo audit configuration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,5 +4,4 @@ ignore = [
   # Okay for local use.
   # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
   "RUSTSEC-2024-0370", # This is a warning about `proc-macro-errors` being unmaintained. It's a transitive dependency of `sigstore` and `oci-spec`.
-  "RUSTSEC-2023-0055", # This is a warning about `lexical` having multiple soundness issues. It's a transitive dependency of `sigstore`.
 ]


### PR DESCRIPTION
Do not suppress RUSTSEC-2023-0055, the issue has been properly solved.
