### PR TITLE
fix: allow multiple active Rekor keys

### DIFF
--- a/src/trust/sigstore/mod.rs
+++ b/src/trust/sigstore/mod.rs
@@ -191,9 +191,9 @@ impl crate::trust::TrustRoot for SigstoreTrustRoot {
     fn rekor_keys(&self) -> Result<Vec<&[u8]>> {
         let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.tlogs).collect();
 
-        if keys.len() != 1 {
+        if keys.is_empty() {
             Err(SigstoreError::TufMetadataError(
-                "Did not find exactly 1 active Rekor key".into(),
+                "Did not find at least 1 active Rekor key".into(),
             ))
         } else {
             Ok(keys)


### PR DESCRIPTION
The Sigstore trusted root metadata now includes multiple active Rekor keys. Update validation to require at least one active key instead of exactly one, allowing the library to work with multiple Rekor instances.

Fixes #501

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

#### Manual verification

export RUSTFLAGS="-A clippy::uninlined_format_args -A deprecated"
make lint (/)
make test (/)
make lint (/)