### PR TITLE
ci: add Zizmor, apply security recommendations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,12 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/auto-publish-crates-upon-release.yml
+++ b/.github/workflows/auto-publish-crates-upon-release.yml
@@ -3,12 +3,19 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-automatically:
+    name: Publish crates
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      id-token: write # needed to get OpenID Connect token for authentication
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -2,8 +2,16 @@ on: [workflow_dispatch]
 
 name: Conformance Suite
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conformance:
+    name: Check sigstore conformance
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,8 +9,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
+    name: Audit for vulnerable crates
     permissions:
       checks: write # for rustsec/audit-check to create check
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,13 @@ on: [push, pull_request]
 
 name: Continuous integration
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check features

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: 'zizmor: GitHub Actions Security Analysis'
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # needed to create vulnerability alerts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+        with:
+          persona: pedantic


### PR DESCRIPTION
* Add Zizmor workflow for static analysis of GitHub actions.
* Add 7-day cooldown timer to Dependabot updates, which helps with stability and supply-chain security. For more info, see: https://docs.zizmor.sh/audits/#dependabot-cooldown
* Remove unnecessary permissions from CI workflows.
* Add concurrency limits to avoid redundant workflow runs.