### PR TITLE
chore: remove `ring` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ verify = [
     "fulcio",
     "rekor",
 ]
-wasm = ["chrono/wasmbind", "getrandom/js", "ring?/wasm32_unknown_unknown_js"]
+wasm = ["chrono/wasmbind", "getrandom/js"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true, default-features = false }
@@ -162,7 +162,6 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "multipart",
 ], optional = true }
-ring = { version = "0.17", default-features = false, optional = true }
 rsa = { version = "0.9", default-features = false, features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = [
     "std",


### PR DESCRIPTION
I didn't see it being used anywhere.