### PR TITLE
chore: replace olpc-cjson with serde_json_canonicalizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ cosign = [
     "dep:async-trait",
     "dep:cfg-if",
     "dep:oci-client",
-    "dep:olpc-cjson",
     "dep:regex",
+    "dep:serde_json_canonicalizer",
     "registry",
 ]
 fulcio = [
@@ -49,7 +49,7 @@ native-tls = [
     "reqwest?/native-tls",
 ]
 oauth = ["dep:openidconnect", "dep:reqwest"]
-registry = ["dep:async-trait", "dep:oci-client", "dep:olpc-cjson"]
+registry = ["dep:async-trait", "dep:oci-client", "dep:serde_json_canonicalizer"]
 rekor = ["dep:reqwest"]
 rustls-tls = [
     "oci-client?/rustls-tls",
@@ -127,7 +127,6 @@ hex = { version = "0.4", default-features = false, optional = true, features = [
     "std",
 ] }
 oci-client = { version = "0.15", default-features = false, optional = true }
-olpc-cjson = { version = "0.1", default-features = false, optional = true }
 openidconnect = { version = "4.0", default-features = false, features = [
     "reqwest",
     "reqwest-blocking",

--- a/src/cosign/bundle.rs
+++ b/src/cosign/bundle.rs
@@ -15,7 +15,6 @@
 
 use std::{cmp::PartialEq, collections::BTreeMap};
 
-use olpc_cjson::CanonicalFormatter;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -87,9 +86,7 @@ impl Bundle {
         bundle: &Bundle,
         rekor_pub_keys: &BTreeMap<String, CosignVerificationKey>,
     ) -> Result<()> {
-        let mut buf = Vec::new();
-        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
-        bundle.payload.serialize(&mut ser).map_err(|e| {
+        let buf = serde_json_canonicalizer::to_vec(&bundle.payload).map_err(|e| {
             SigstoreError::UnexpectedError(format!(
                 "Cannot create canonical JSON representation of bundle: {e:?}"
             ))


### PR DESCRIPTION
#### Summary

The `serde_json_canonicalizer` crate was adopted as a replacement for `json-syntax` in 9b425a660837d920fc5e1200790ad2de5414f840. As noted in the discussion in #510, `olpc-cjson` was used elsewhere in the code for JSON canonicalization; I think it makes sense to use the same canonicalization scheme throughout the codebase, especially given that the schemes can slightly differ in edge cases, and `serde_json_canonicalizer` is designed to be strictly RFC 8785-compliant. This allows dropping the `olpc-cjson` dependency.

#### Release Note

NONE

#### Documentation

N/A