### PR TITLE
feat: load trusted roots from TrustClientConfig.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -162,6 +162,9 @@ pub enum SigstoreError {
     #[error("Sigstore bundle malformed: {0}")]
     SigstoreBundleMalformedError(String),
 
+    #[error("Sigstore PKI file is malformed: {0}")]
+    SigstorePKIFileMalformedError(String),
+
     #[error("Layer doesn't have Sigstore media type")]
     SigstoreMediaTypeNotFoundError,
 
@@ -193,6 +196,13 @@ pub enum SigstoreError {
 
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+
+    #[error("IOError: {context}: {source}")]
+    IOErrorWithContext {
+        context: String,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("{0}")]
     UnexpectedError(String),


### PR DESCRIPTION
#### Summary

Adds a helper function to be used by clients to build a SigstoreTrustRoot from a JSON file following the [TrustClientConfig](https://github.com/sigstore/protobuf-specs/blob/4d38e4482bf67c7ab86bf2f61e8d79010ac0974e/protos/sigstore_trustroot.proto#L341) protobuf spec.

Closes https://github.com/sigstore/sigstore-rs/issues/525


#### Release Note

New function to allow clients to load the trusted roots from [TrustClientConfig](https://github.com/sigstore/protobuf-specs/blob/4d38e4482bf67c7ab86bf2f61e8d79010ac0974e/protos/sigstore_trustroot.proto#L341) JSON files


