### PR TITLE
refactor(crypto): use awl-lc-rs in ecdsa module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["full", "native-tls"]
 
 bundle = ["sign", "verify"]
 cached-client = ["dep:cached"]
-cert = ["dep:aws-lc-rs", "rustls-webpki/aws-lc-rs"]
+cert = ["rustls-webpki/aws-lc-rs"]
 cosign = [
     "cert",
     "dep:async-trait",
@@ -231,10 +231,10 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
-aws-lc-rs = { version = "1", optional = true }
+aws-lc-rs = { version = "1" }
 
 [target.'cfg(target_arch = "powerpc64")'.dependencies]
-aws-lc-rs = { version = "1", optional = true, features = ["bindgen"] }
+aws-lc-rs = { version = "1", features = ["bindgen"] }
 
 # cosign example mappings
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,7 +15,7 @@
 
 //! Structures and constants required to perform cryptographic operations.
 
-use sha2::{Sha256, Sha384};
+use aws_lc_rs::signature::{ECDSA_P256_SHA256_ASN1_SIGNING, ECDSA_P384_SHA384_ASN1_SIGNING};
 
 use crate::errors::*;
 
@@ -99,10 +99,10 @@ impl SigningScheme {
     pub fn create_signer(&self) -> Result<SigStoreSigner> {
         Ok(match self {
             SigningScheme::ECDSA_P256_SHA256_ASN1 => SigStoreSigner::ECDSA_P256_SHA256_ASN1(
-                EcdsaSigner::<_, Sha256>::from_ecdsa_keys(&EcdsaKeys::<p256::NistP256>::new()?)?,
+                EcdsaSigner::from_ecdsa_keys(&EcdsaKeys::new(&ECDSA_P256_SHA256_ASN1_SIGNING)?)?,
             ),
             SigningScheme::ECDSA_P384_SHA384_ASN1 => SigStoreSigner::ECDSA_P384_SHA384_ASN1(
-                EcdsaSigner::<_, Sha384>::from_ecdsa_keys(&EcdsaKeys::<p384::NistP384>::new()?)?,
+                EcdsaSigner::from_ecdsa_keys(&EcdsaKeys::new(&ECDSA_P384_SHA384_ASN1_SIGNING)?)?,
             ),
             SigningScheme::ED25519 => {
                 SigStoreSigner::ED25519(Ed25519Signer::from_ed25519_keys(&Ed25519Keys::new()?)?)

--- a/src/crypto/signing_key/mod.rs
+++ b/src/crypto/signing_key/mod.rs
@@ -316,8 +316,8 @@ pub enum SigStoreSigner {
     RSA_PKCS1_SHA256(RSASigner),
     RSA_PKCS1_SHA384(RSASigner),
     RSA_PKCS1_SHA512(RSASigner),
-    ECDSA_P256_SHA256_ASN1(EcdsaSigner<p256::NistP256, sha2::Sha256>),
-    ECDSA_P384_SHA384_ASN1(EcdsaSigner<p384::NistP384, sha2::Sha384>),
+    ECDSA_P256_SHA256_ASN1(EcdsaSigner),
+    ECDSA_P384_SHA384_ASN1(EcdsaSigner),
     ED25519(Ed25519Signer),
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -231,6 +231,9 @@ pub enum SigstoreError {
     #[error(transparent)]
     ECDSAError(#[from] ecdsa::Error),
 
+    #[error("Failed to generate ECDSA key pair")]
+    FailedToGenerateEcdsaKeys,
+
     #[error(transparent)]
     ECError(#[from] elliptic_curve::Error),
 
@@ -272,4 +275,10 @@ pub enum SigstoreError {
 
     #[error(transparent)]
     X509BuilderError(#[from] x509_cert::builder::Error),
+
+    #[error("Failed to sign the data")]
+    FailedToSignError,
+
+    #[error("Unsupported ECDSA signing algorithm")]
+    UnsupportedAlgorithmError,
 }


### PR DESCRIPTION
#### Summary

Updates the code that generates, parses and signs using ECDSA keys to use the aws-lc-rs crate. Therefore, all the references to other crypto libraries has been removed.

The first change the starts to fix the issue #307. 

> [!WARNING]
> Remeber this is **not** a complete change. It's the first of a series of changes in the crypto module to replace crypto libraries in favor of `aws-lc-rs`. See the proposed change [here](https://github.com/sigstore/sigstore-rs/issues/307#issuecomment-3616705700)


#### Release Note

The `EcdsaKeys` struct now requires the callers to algorithm used in the keys they want to parse. This is a required argument to the underling `aws-lc-rs` crate. 