### PR TITLE
refactor: remove wasm workarounds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           tool: cargo-hack
       - run: |
-          cargo hack check --feature-powerset --features native-tls --skip wasm --skip test-registry --skip rustls-tls --skip rustls-tls-native-roots
+          cargo hack check --feature-powerset --features native-tls --skip test-registry --skip rustls-tls --skip rustls-tls-native-roots
 
   check-rustls-tls:
     name: Check rusttls-tls features
@@ -55,7 +55,7 @@ jobs:
         with:
           tool: cargo-hack
       - run: |
-          cargo hack check --feature-powerset --features rustls-tls --skip wasm --skip test-registry --skip native-tls
+          cargo hack check --feature-powerset --features rustls-tls --skip test-registry --skip native-tls
 
   test-native-tls:
     name: Test Suite

--- a/README.md
+++ b/README.md
@@ -64,16 +64,6 @@ For example, `openidconnect` can be run with the following command:
 cargo run --example openidconnect
 ```
 
-## WebAssembly/WASM support
-
-To embedded this crate in WASM modules, build it using the `wasm` cargo feature:
-
-```bash
-cargo build --no-default-features --features wasm --target wasm32-unknown-unknown
-```
-
-NOTE: The wasm32-wasi target architecture is not yet supported.
-
 ## Contributing
 
 Contributions are welcome! Please see the [contributing guidelines](CONTRIBUTORS.md)

--- a/src/cosign/client.rs
+++ b/src/cosign/client.rs
@@ -43,8 +43,7 @@ pub struct Client {
     pub(crate) fulcio_cert_pool: Option<CertificatePool>,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl CosignCapabilities for Client {
     async fn triangulate(
         &mut self,

--- a/src/cosign/mod.rs
+++ b/src/cosign/mod.rs
@@ -70,8 +70,7 @@ pub use payload::simple_signing;
 
 pub mod constraint;
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 /// Cosign Abilities that have to be implemented by a
 /// Cosign client
 pub trait CosignCapabilities {

--- a/src/mock_client.rs
+++ b/src/mock_client.rs
@@ -35,8 +35,7 @@ pub(crate) mod test {
 
     impl crate::registry::ClientCapabilitiesDeps for MockOciClient {}
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[async_trait]
     impl crate::registry::ClientCapabilities for MockOciClient {
         async fn fetch_manifest_digest(
             &mut self,

--- a/src/oauth/http_client.rs
+++ b/src/oauth/http_client.rs
@@ -33,9 +33,6 @@ pub(crate) struct AsyncReqwestClient(pub reqwest::Client);
 impl<'c> AsyncHttpClient<'c> for AsyncReqwestClient {
     type Error = HttpClientError<reqwest::Error>;
 
-    #[cfg(target_arch = "wasm32")]
-    type Future = Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c>>;
-    #[cfg(not(target_arch = "wasm32"))]
     type Future =
         Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + Send + Sync + 'c>>;
 
@@ -47,12 +44,9 @@ impl<'c> AsyncHttpClient<'c> for AsyncReqwestClient {
                 .await
                 .map_err(Box::new)?;
 
-            let mut builder = http::Response::builder().status(response.status());
-
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                builder = builder.version(response.version());
-            }
+            let mut builder = http::Response::builder()
+                .status(response.status())
+                .version(response.version());
 
             for (name, value) in response.headers().iter() {
                 builder = builder.header(name, value);
@@ -67,12 +61,8 @@ impl<'c> AsyncHttpClient<'c> for AsyncReqwestClient {
 
 /// A wrapper around [`reqwest::blocking::Client`] that implements [`SyncHttpClient`]
 /// for use with the `openidconnect` crate.
-///
-/// Not available on `wasm32` targets.
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct SyncReqwestClient(pub reqwest::blocking::Client);
 
-#[cfg(not(target_arch = "wasm32"))]
 impl SyncHttpClient for SyncReqwestClient {
     type Error = HttpClientError<reqwest::Error>;
 

--- a/src/oauth/openidflow.rs
+++ b/src/oauth/openidflow.rs
@@ -16,7 +16,7 @@
 //! This provides a method for retreiving a OpenID Connect ID Token and scope from the sigstore project.
 //!
 //! The main entry points are:
-//! - [`OpenIDAuthorize::auth_url`](OpenIDAuthorize::auth_url) (synchronous, non-wasm only)
+//! - [`OpenIDAuthorize::auth_url`](OpenIDAuthorize::auth_url) (synchronous)
 //! - [`OpenIDAuthorize::auth_url_async`](OpenIDAuthorize::auth_url_async) (async)
 //!
 //! Both require four parameters:
@@ -40,7 +40,7 @@
 //!   value.
 //!
 //! Once you have recieved the above tuple, you can use:
-//! - [`RedirectListener::redirect_listener`](RedirectListener::redirect_listener) (synchronous, non-wasm only)
+//! - [`RedirectListener::redirect_listener`](RedirectListener::redirect_listener) (synchronous)
 //! - [`RedirectListener::redirect_listener_async`](RedirectListener::redirect_listener_async) (async)
 //!
 //! to get the ID Token and scope.
@@ -100,7 +100,6 @@ use url::Url;
 
 use crate::errors::{Result, SigstoreError};
 use crate::oauth::http_client::AsyncReqwestClient;
-#[cfg(not(target_arch = "wasm32"))]
 use crate::oauth::http_client::SyncReqwestClient;
 
 pub(crate) type OpenIdClient = openidconnect::core::CoreClient<
@@ -172,7 +171,6 @@ impl OpenIDAuthorize {
         Ok((authorize_url, client, nonce, pkce_verifier))
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn auth_url(&self) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
         let http_client = SyncReqwestClient(
             reqwest::blocking::ClientBuilder::new()
@@ -301,7 +299,6 @@ impl RedirectListener {
         Err(SigstoreError::CodePairError)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn redirect_listener(self) -> Result<(CoreIdTokenClaims, CoreIdToken)> {
         let http_client = SyncReqwestClient(
             reqwest::blocking::ClientBuilder::new()
@@ -382,7 +379,6 @@ mod tests {
         assert!(url.contains("scope=openid+email"));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_auth_url() {
         let oidc_url = OpenIDAuthorize::new(

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -37,28 +37,9 @@ use async_trait::async_trait;
 
 use ::oci_client as oci_client_dep;
 
-/// Workaround to ensure the `Send + Sync` supertraits are
-/// required by ClientCapabilities only when the target
-/// architecture is NOT wasm32.
-///
-/// This intermediate trait has been created to avoid
-/// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
-/// the other with `#[cfg(not(target_arch = "wasm32"))]`
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) trait ClientCapabilitiesDeps: Send + Sync {}
 
-/// Workaround to ensure the `Send + Sync` supertraits are
-/// required by ClientCapabilities only when the target
-/// architecture is NOT wasm32.
-///
-/// This intermediate trait has been created to avoid
-/// to define ClientCapabilities twice (one with `#[cfg(target_arch = "wasm32")]`,
-/// the other with `#[cfg(not(target_arch = "wasm32"))]`
-#[cfg(target_arch = "wasm32")]
-pub(crate) trait ClientCapabilitiesDeps {}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 /// Capabilities that are expected to be provided by a registry client
 pub(crate) trait ClientCapabilities: ClientCapabilitiesDeps {
     async fn fetch_manifest_digest(

--- a/src/registry/oci_caching_client.rs
+++ b/src/registry/oci_caching_client.rs
@@ -243,8 +243,7 @@ async fn pull_manifest_cached(
 
 impl ClientCapabilitiesDeps for OciCachingClient {}
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(? Send))]
+#[async_trait]
 impl ClientCapabilities for OciCachingClient {
     async fn fetch_manifest_digest(
         &mut self,

--- a/src/registry/oci_client.rs
+++ b/src/registry/oci_client.rs
@@ -29,8 +29,7 @@ pub(crate) struct OciClient {
 
 impl ClientCapabilitiesDeps for OciClient {}
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait]
 impl ClientCapabilities for OciClient {
     async fn fetch_manifest_digest(
         &mut self,


### PR DESCRIPTION
Since the wasm target is no longer supported, remove all the conditional compilations configuration.

This makes the code easier to read and maintain.
