### PR TITLE
ci: Add release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  workflow_dispatch:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,10 +21,14 @@ Full test suite requires Docker daemon to be running (and the user must have per
    new or changed configuration values.
 5. Correctly format your commit message see [Commit Messages](#commit-message-guidelines)
    below.
-6. Ensure that CI passes, if it fails, fix the failures.
-7. Every pull request requires a review from the [core sigstore-rs team](https://github.com/orgs/github.com/sigstore/teams/sigstore-rs-codeowners)
+6. Format your PR title in a [conventional
+   commit](https://www.conventionalcommits.org/en/v1.0.0/) style, for
+   [release-drafter](https://github.com/release-drafter/release-drafter) to
+   draft the changelog in a GH draft release.
+7. Ensure that CI passes, if it fails, fix the failures.
+8. Every pull request requires a review from the [core sigstore-rs team](https://github.com/orgs/github.com/sigstore/teams/sigstore-rs-codeowners)
    before merging.
-8. If your pull request consists of more than one commit, please squash your
+9. If your pull request consists of more than one commit, please squash your
    commits as described in [Squash Commits](#squash-commits)
 
 ## Commit Message Guidelines


### PR DESCRIPTION
#### Summary

Automate GH release changelogs with
[release-drafter](https://github.com/release-drafter/release-drafter). release-drafter is GitHub Action that when run, creates a draft GH release, filled with the content of pull request titles. It only takes into account PR tiles written in [conventional
commits](https://www.conventionalcommits.org/en/v1.0.0/) (PR titles, not commit history).

PR titles are easily edited by maintainers, even after merge.

#### Release Note

After merge, this will be taken care by release-drafter.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Changed CONTRIBUTORS.md.