### PR TITLE
fix(bundle/sign): disambiguate email bytes in CSR attribute

### DIFF
--- a/src/bundle/sign.rs
+++ b/src/bundle/sign.rs
@@ -97,7 +97,7 @@ impl<'ctx> SigningSession<'ctx> {
                             oid: const_oid::db::rfc3280::EMAIL_ADDRESS,
                             value: AttributeValue::new(
                                 pkcs8::der::Tag::Utf8String,
-                                token.unverified_claims().email.as_ref(),
+                                token.unverified_claims().email.as_str().as_bytes(),
                             )?,
                         }
                     ].try_into()?


### PR DESCRIPTION
`SigningSession::materials` builds the CSR's emailAddress attribute via `AttributeValue::new(Tag::Utf8String, token.unverified_claims().email.as_ref())`. The `as_ref()` is under-constrained: when the compiled graph also contains `hybrid-array` (whose `impl<T,U> From<&Array<T,U>> for Box<[T]>` adds a second candidate), `Any::new(impl Into<Box<[u8]>>)` can no longer infer the reference type → `E0283` ("multiple impls satisfying `Box<[u8]>: From<&_>` found in: alloc, hybrid_array").

This makes sigstore-rs fail to compile in any workspace that also pulls `hybrid-array` (e.g. alongside `russh` → `ed25519-dalek` 3.0.0-pre), while compiling cleanly in isolation — which is why it's hard to spot upstream.

**Fix:** pin the conversion explicitly — `email.as_str().as_bytes()` is the `&[u8]` the DER encoder expects, removing the ambiguity regardless of which array crates are linked. No behaviour change in isolation (resolved bytes are identical); restores compilability in graphs that include `hybrid-array`.

Confirmed: with this change, sigstore-rs compiles both in isolation and in a workspace that also depends on `russh` + `ed25519-dalek` 3.0.0-pre (which was previously failing at `bundle/sign.rs:100`).

Same one-line change applies to the released 0.14 tag.
