### PR TITLE
feat:  arbitrary in-toto attestation predicate type support

### DIFF
--- a/examples/cosign/verify/main.rs
+++ b/examples/cosign/verify/main.rs
@@ -16,8 +16,8 @@
 extern crate sigstore;
 use sigstore::cosign::verification_constraint::cert_subject_email_verifier::StringVerifier;
 use sigstore::cosign::verification_constraint::{
-    AnnotationVerifier, CertSubjectEmailVerifier, CertSubjectUrlVerifier, CertificateVerifier,
-    PublicKeyVerifier, VerificationConstraintVec,
+    AnnotationVerifier, AttestationVerifier, CertSubjectEmailVerifier, CertSubjectUrlVerifier,
+    CertificateVerifier, PublicKeyVerifier, VerificationConstraintVec,
 };
 use sigstore::cosign::{CosignCapabilities, SignatureLayer};
 use sigstore::crypto::SigningScheme;
@@ -99,6 +99,10 @@ struct Cli {
 
     /// Name of the image to verify
     image: OciReference,
+
+    /// Require an in-toto attestation with this predicate type (e.g. https://slsa.dev/provenance/v1)
+    #[clap(long, required(false))]
+    predicate_type: Option<String>,
 
     /// Whether the registry uses HTTP
     #[clap(long)]
@@ -217,6 +221,11 @@ async fn run_app(
         }
     }
 
+    if let Some(predicate_type) = cli.predicate_type.as_ref() {
+        let verifier = AttestationVerifier::new().with_predicate_type(predicate_type);
+        verification_constraints.push(Box::new(verifier));
+    }
+
     let image = &cli.image;
 
     let trusted_layers = client.trusted_signature_layers(auth, image).await?;
@@ -296,6 +305,18 @@ pub async fn main() {
                 match filter_result {
                     Ok(()) => {
                         println!("Image successfully verified");
+                        for layer in &trusted_layers {
+                            if let Some(predicate_type) = layer.attestation_predicate_type() {
+                                println!("  attestation predicate type: {predicate_type}");
+                                if let Some(predicate) = layer.attestation_predicate() {
+                                    println!(
+                                        "  attestation predicate: {}",
+                                        serde_json::to_string_pretty(predicate)
+                                            .unwrap_or_else(|_| format!("{predicate:?}"))
+                                    );
+                                }
+                            }
+                        }
                     }
                     Err(SigstoreVerifyConstraintsError {
                         unsatisfied_constraints,

--- a/src/bundle/intoto.rs
+++ b/src/bundle/intoto.rs
@@ -51,14 +51,14 @@ impl InTotoStatementV1 {
     /// Validate the in-toto statement and verify that at least one subject
     /// carries a digest matching `expected_digest`.
     ///
-    /// `expected_digest` must be in `algorithm:hex` form (e.g.
-    /// `"sha256:abc123"`, `"sha512:def456"`).  An error is returned if the
-    /// `':'` separator is missing.
+    /// `expected_digest` should be in `algorithm:hex` form (e.g.
+    /// `"sha256:abc123"`, `"sha512:def456"`).  If the `':'` separator is
+    /// missing, no subject will match and the error message will include the
+    /// full subject list for debuggability.
     ///
     /// Checks performed:
     ///
     /// - `_type` must be `https://in-toto.io/Statement/v1`
-    /// - `expected_digest` must be in `algorithm:hex` format
     /// - At least one subject must have a digest entry for the extracted
     ///   algorithm whose value equals the extracted hex digest
     ///
@@ -74,11 +74,9 @@ impl InTotoStatementV1 {
             )));
         }
 
-        let (algorithm, digest) = expected_digest.split_once(':').ok_or_else(|| {
-            SigstoreError::UnexpectedError(format!(
-                "expected_digest must be in 'algorithm:hex' format, got '{expected_digest}'"
-            ))
-        })?;
+        let (algorithm, digest) = expected_digest
+            .split_once(':')
+            .unwrap_or(("", expected_digest));
 
         let found = self
             .subject
@@ -87,7 +85,7 @@ impl InTotoStatementV1 {
 
         if !found {
             return Err(SigstoreError::UnexpectedError(format!(
-                "unable to find subject with mathcing digest; digest: '{algorithm}:{digest}'; subjects: {:?}",
+                "unable to find subject with matching digest; expected: '{expected_digest}'; subjects: {:?}",
                 self.subject
             )));
         }

--- a/src/bundle/intoto.rs
+++ b/src/bundle/intoto.rs
@@ -17,12 +17,10 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 use crate::errors::{Result, SigstoreError};
 
 const IN_TOTO_STATEMENT_V1_TYPE: &str = "https://in-toto.io/Statement/v1";
-const COSIGN_SIGN_V1_PREDICATE_TYPE: &str = "https://sigstore.dev/cosign/sign/v1";
 
 /// An in-toto Statement v1 as defined in <https://in-toto.io/Statement/v1>.
 ///
@@ -44,34 +42,31 @@ pub(crate) struct InTotoStatementV1 {
 
 impl InTotoStatementV1 {
     /// Parse an in-toto Statement v1 from raw JSON bytes.
-    pub fn from_json(bytes: &[u8]) -> Result<Self> {
+    pub(crate) fn from_json(bytes: &[u8]) -> Result<Self> {
         serde_json::from_slice(bytes).map_err(|e| {
             SigstoreError::UnexpectedError(format!("cannot parse in-toto statement: {e}"))
         })
     }
 
-    /// Enforce that the statement satisfies the subset of the
-    /// [in-toto Statement v1 spec](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md)
-    /// that Sigstore / cosign sign-v1 cares about:
+    /// Validate the in-toto statement and verify that at least one subject
+    /// carries a digest matching `expected_digest`.
+    ///
+    /// `expected_digest` must be in `algorithm:hex` form (e.g.
+    /// `"sha256:abc123"`, `"sha512:def456"`).  An error is returned if the
+    /// `':'` separator is missing.
+    ///
+    /// Checks performed:
     ///
     /// - `_type` must be `https://in-toto.io/Statement/v1`
-    /// - `predicateType` must be `https://sigstore.dev/cosign/sign/v1`
-    /// - `subject` must be non-empty
-    /// - `subject[0]` must carry a `sha256` digest entry
+    /// - `expected_digest` must be in `algorithm:hex` format
+    /// - At least one subject must have a digest entry for the extracted
+    ///   algorithm whose value equals the extracted hex digest
     ///
-    /// # What we currently ignore (and why)
-    ///
-    /// - **Multiple subjects**: the spec allows any number of subjects.
-    ///   Go cosign and sigstore-go both iterate all subjects when matching
-    ///   against an artifact digest; we only consume `subject[0]` for now.
-    ///   A warning is emitted if more than one subject is present so that
-    ///   the behaviour is visible.
-    /// - **Extra digest algorithms**: subject digest maps may contain
-    ///   entries beyond `sha256` (e.g. `sha512`).  We only read `sha256`
-    ///   and silently ignore the rest, matching Go cosign's behaviour.
-    /// - **`predicate` field**: not inspected; callers that need to verify
-    ///   the predicate payload must do so themselves.
-    pub fn validate_cosign_v1(&self) -> Result<()> {
+    /// The `predicateType` is **not** restricted — any predicate type is
+    /// accepted (e.g. `cosign/sign/v1`, SLSA provenance, SBOM, etc.).
+    /// Callers that need to enforce a specific predicate type should inspect
+    /// [`Self::predicate_type`] after validation.
+    pub fn validate(&self, expected_digest: &str) -> Result<()> {
         if self.statement_type != IN_TOTO_STATEMENT_V1_TYPE {
             return Err(SigstoreError::UnexpectedError(format!(
                 "unsupported in-toto _type: expected {IN_TOTO_STATEMENT_V1_TYPE}, got {}",
@@ -79,30 +74,22 @@ impl InTotoStatementV1 {
             )));
         }
 
-        if self.predicate_type != COSIGN_SIGN_V1_PREDICATE_TYPE {
+        let (algorithm, digest) = expected_digest.split_once(':').ok_or_else(|| {
+            SigstoreError::UnexpectedError(format!(
+                "expected_digest must be in 'algorithm:hex' format, got '{expected_digest}'"
+            ))
+        })?;
+
+        let found = self
+            .subject
+            .iter()
+            .any(|s| s.digest.get(algorithm).is_some_and(|d| d == digest));
+
+        if !found {
             return Err(SigstoreError::UnexpectedError(format!(
-                "unsupported in-toto predicateType: expected {COSIGN_SIGN_V1_PREDICATE_TYPE}, got {}",
-                self.predicate_type
+                "unable to find subject with mathcing digest; digest: '{algorithm}:{digest}'; subjects: {:?}",
+                self.subject
             )));
-        }
-
-        if self.subject.is_empty() {
-            return Err(SigstoreError::UnexpectedError(
-                "in-toto statement has no subjects".to_string(),
-            ));
-        }
-
-        if self.subject.len() > 1 {
-            warn!(
-                subject_count = self.subject.len(),
-                "in-toto statement has multiple subjects; only the first will be used"
-            );
-        }
-
-        if !self.subject[0].digest.contains_key("sha256") {
-            return Err(SigstoreError::UnexpectedError(
-                "in-toto statement subject[0] has no sha256 digest".to_string(),
-            ));
         }
 
         Ok(())
@@ -111,7 +98,7 @@ impl InTotoStatementV1 {
     /// Return the SHA-256 digest of the first subject as a hex string (no
     /// `sha256:` prefix), or an error if the subject list is empty or the
     /// digest is absent.
-    pub fn subject_sha256_digest(&self) -> Result<String> {
+    pub(crate) fn subject_sha256_digest(&self) -> Result<String> {
         self.subject
             .first()
             .and_then(|s| s.digest.get("sha256").cloned())
@@ -159,73 +146,33 @@ mod tests {
         let statement =
             InTotoStatementV1::from_json(&payload_bytes).expect("must parse as in-toto statement");
 
-        assert_eq!(
-            statement.subject_sha256_digest().unwrap(),
-            "c811d58de79c92f03214e63aa339484e488d694ae8a6283b5f3f17a9faf50172"
-        );
+        let has_expected_digest = statement.subject.iter().any(|s| {
+            s.digest.get("sha256")
+                == Some(
+                    &"c811d58de79c92f03214e63aa339484e488d694ae8a6283b5f3f17a9faf50172".to_string(),
+                )
+        });
+        assert!(has_expected_digest);
         assert_eq!(
             statement.predicate_type,
             "https://sigstore.dev/cosign/sign/v1"
         );
         statement
-            .validate_cosign_v1()
-            .expect("real fixture should satisfy cosign v1 statement constraints");
-    }
-
-    #[rstest]
-    #[case::subject_missing_sha256_digest(
-        InTotoStatementV1 {
-            statement_type: "https://in-toto.io/Statement/v1".to_string(),
-            subject: vec![Subject {
-                name: Some("artifact".to_string()),
-                digest: BTreeMap::new(), // no sha256 key
-                annotations: None,
-            }],
-            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
-            predicate: None,
-        }
-    )]
-    #[case::empty_subject_list(
-        InTotoStatementV1 {
-            statement_type: "https://in-toto.io/Statement/v1".to_string(),
-            subject: vec![],
-            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
-            predicate: None,
-        }
-    )]
-    fn subject_sha256_digest_returns_err_for_missing_digest(#[case] statement: InTotoStatementV1) {
-        assert!(statement.subject_sha256_digest().is_err());
+            .validate("sha256:c811d58de79c92f03214e63aa339484e488d694ae8a6283b5f3f17a9faf50172")
+            .expect("real fixture should satisfy statement constraints");
     }
 
     #[test]
-    fn subject_sha256_digest_returns_err_for_invalid_json() {
-        // Simulates what callers do: deserialise raw bytes first, then call the method.
-        // Invalid JSON must produce a deserialisation error before we even reach the method.
+    fn validate_returns_err_for_invalid_json() {
+        // Invalid JSON must produce a deserialisation error before we even reach validate.
         let result = serde_json::from_slice::<InTotoStatementV1>(b"not valid json");
         assert!(result.is_err());
     }
 
     #[rstest]
-    #[case::valid(
-        "https://in-toto.io/Statement/v1",
-        "https://sigstore.dev/cosign/sign/v1",
-        true
-    )]
-    #[case::wrong_statement_type(
-        "https://example.com/Statement/v1",
-        "https://sigstore.dev/cosign/sign/v1",
-        false
-    )]
-    #[case::wrong_predicate_type(
-        "https://in-toto.io/Statement/v1",
-        "https://example.com/predicate/v1",
-        false
-    )]
-    fn validate_cosign_v1_type_enforcement(
-        #[case] statement_type: &str,
-        #[case] predicate_type: &str,
-        #[case] expected_ok: bool,
-    ) {
+    #[case::valid_statement_type("https://in-toto.io/Statement/v1", true)]
+    #[case::wrong_statement_type("https://example.com/Statement/v1", false)]
+    fn validate_type_enforcement(#[case] statement_type: &str, #[case] expected_ok: bool) {
         let statement = InTotoStatementV1 {
             statement_type: statement_type.to_string(),
             subject: vec![Subject {
@@ -233,10 +180,36 @@ mod tests {
                 digest: BTreeMap::from([("sha256".to_string(), "abc".to_string())]),
                 annotations: None,
             }],
-            predicate_type: predicate_type.to_string(),
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
             predicate: None,
         };
-        assert_eq!(statement.validate_cosign_v1().is_ok(), expected_ok);
+        assert_eq!(statement.validate("sha256:abc").is_ok(), expected_ok);
+    }
+
+    #[test]
+    fn validate_accepts_any_predicate_type() {
+        // Any predicate type should be accepted — SLSA provenance, SBOM, etc.
+        for predicate_type in [
+            "https://sigstore.dev/cosign/sign/v1",
+            "https://slsa.dev/provenance/v1",
+            "https://cyclonedx.org/bom/v1.4",
+            "https://example.com/custom/v1",
+        ] {
+            let statement = InTotoStatementV1 {
+                statement_type: "https://in-toto.io/Statement/v1".to_string(),
+                subject: vec![Subject {
+                    name: Some("artifact".to_string()),
+                    digest: BTreeMap::from([("sha256".to_string(), "abc".to_string())]),
+                    annotations: None,
+                }],
+                predicate_type: predicate_type.to_string(),
+                predicate: None,
+            };
+            assert!(
+                statement.validate("sha256:abc").is_ok(),
+                "predicate type {predicate_type} should be accepted"
+            );
+        }
     }
 
     #[rstest]
@@ -246,7 +219,8 @@ mod tests {
             subject: vec![],
             predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
             predicate: None,
-        }
+        },
+        "sha256:abc"
     )]
     #[case::subject_without_sha256(
         InTotoStatementV1 {
@@ -258,16 +232,44 @@ mod tests {
             }],
             predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
             predicate: None,
-        }
+        },
+        "sha256:abc"
     )]
-    fn validate_cosign_v1_rejects_invalid_subject(#[case] statement: InTotoStatementV1) {
-        assert!(statement.validate_cosign_v1().is_err());
+    #[case::no_matching_digest(
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![Subject {
+                name: Some("artifact".to_string()),
+                digest: BTreeMap::from([("sha256".to_string(), "aaa".to_string())]),
+                annotations: None,
+            }],
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
+            predicate: None,
+        },
+        "sha256:bbb"
+    )]
+    #[case::missing_algorithm_prefix(
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![Subject {
+                name: Some("artifact".to_string()),
+                digest: BTreeMap::from([("sha256".to_string(), "abc".to_string())]),
+                annotations: None,
+            }],
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
+            predicate: None,
+        },
+        "abc"
+    )]
+    fn validate_rejects_invalid_subject(
+        #[case] statement: InTotoStatementV1,
+        #[case] expected_digest: &str,
+    ) {
+        assert!(statement.validate(expected_digest).is_err());
     }
 
-    // Multiple subjects are accepted (with a warn!); only subject[0] is used.
-    // Extra digest algorithms beyond sha256 are tolerated and ignored.
     #[rstest]
-    #[case::multiple_subjects(
+    #[case::digest_in_first_subject(
         InTotoStatementV1 {
             statement_type: "https://in-toto.io/Statement/v1".to_string(),
             subject: vec![
@@ -284,7 +286,28 @@ mod tests {
             ],
             predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
             predicate: None,
-        }
+        },
+        "sha256:aaa"
+    )]
+    #[case::digest_in_second_subject(
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![
+                Subject {
+                    name: Some("artifact-a".to_string()),
+                    digest: BTreeMap::from([("sha256".to_string(), "aaa".to_string())]),
+                    annotations: None,
+                },
+                Subject {
+                    name: Some("artifact-b".to_string()),
+                    digest: BTreeMap::from([("sha256".to_string(), "bbb".to_string())]),
+                    annotations: None,
+                },
+            ],
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
+            predicate: None,
+        },
+        "sha256:bbb"
     )]
     #[case::extra_digest_algorithms(
         InTotoStatementV1 {
@@ -299,9 +322,39 @@ mod tests {
             }],
             predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
             predicate: None,
-        }
+        },
+        "sha256:abc"
     )]
-    fn validate_cosign_v1_accepts_tolerated_cases(#[case] statement: InTotoStatementV1) {
-        assert!(statement.validate_cosign_v1().is_ok());
+    #[case::sha256_prefix(
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![Subject {
+                name: Some("artifact".to_string()),
+                digest: BTreeMap::from([("sha256".to_string(), "abc".to_string())]),
+                annotations: None,
+            }],
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
+            predicate: None,
+        },
+        "sha256:abc"
+    )]
+    #[case::sha512_algorithm(
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![Subject {
+                name: Some("artifact".to_string()),
+                digest: BTreeMap::from([("sha512".to_string(), "def456".to_string())]),
+                annotations: None,
+            }],
+            predicate_type: "https://sigstore.dev/cosign/sign/v1".to_string(),
+            predicate: None,
+        },
+        "sha512:def456"
+    )]
+    fn validate_accepts_valid_cases(
+        #[case] statement: InTotoStatementV1,
+        #[case] expected_digest: &str,
+    ) {
+        assert!(statement.validate(expected_digest).is_ok());
     }
 }

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -119,6 +119,15 @@ pub enum CertificateSubject {
 pub struct SignatureLayer {
     /// The Simple Signing object associated with this layer
     pub simple_signing: SimpleSigning,
+    /// The in-toto attestation from a verified Sigstore Bundle (DSSE envelope).
+    ///
+    /// This is `Some` when the layer was constructed from a Sigstore Bundle
+    /// containing a DSSE envelope with an in-toto Statement v1 payload.
+    /// It is `None` for tag-based SimpleSigning layers.
+    ///
+    /// The attestation is available for inspection after cryptographic
+    /// verification (e.g. to check the `predicate_type` or `predicate`).
+    pub(crate) attestation: Option<super::intoto::InTotoStatementV1>,
     /// The digest of the layer
     pub oci_digest: String,
     /// The certificate holding the identity of the signer, plus his
@@ -225,6 +234,7 @@ impl SignatureLayer {
         let digest = format!("sha256:{:x}", sha2::Sha256::digest(&payload));
         Ok(SignatureLayer {
             simple_signing,
+            attestation: None,
             oci_digest: digest,
             certificate_signature: None,
             bundle: None,
@@ -295,6 +305,7 @@ impl SignatureLayer {
             oci_digest: descriptor.digest.clone(),
             raw_data: layer.data.to_vec(),
             simple_signing,
+            attestation: None,
             signature: Some(signature),
             bundle,
             certificate_signature,
@@ -444,18 +455,12 @@ impl SignatureLayer {
         // Decode the in-toto Statement v1 from the envelope payload
         // dsse_env.payload is already raw bytes (proto bytes field).
         let statement = InTotoStatementV1::from_json(&dsse_env.payload)?;
-        statement.validate_cosign_v1()?;
+        statement.validate(source_image_digest)?;
 
-        // Verify that the in-toto statement covers the expected image digest.
-        let subject_digest = statement.subject_sha256_digest()?;
-        let expected_digest = source_image_digest
+        // Extract the first matching subject digest for the synthesised SimpleSigning.
+        let subject_digest = source_image_digest
             .strip_prefix("sha256:")
             .unwrap_or(source_image_digest);
-        if subject_digest != expected_digest {
-            return Err(SigstoreError::UnexpectedError(format!(
-                "Sigstore bundle subject digest {subject_digest} does not match source image digest {source_image_digest}"
-            )));
-        }
 
         // Build the DSSE PAE bytes (what was actually signed)
         let pae_bytes =
@@ -563,6 +568,7 @@ impl SignatureLayer {
 
         Ok(SignatureLayer {
             simple_signing,
+            attestation: Some(statement),
             oci_digest: layer_digest.to_string(),
             certificate_signature,
             bundle: Some(BundleContent::SigstoreBundle(tlog_entry)),
@@ -1253,6 +1259,7 @@ OSWS1X9vPavpiQOoTTGC0xX57OojUadxF1cdQmrsiReWg2Wn4FneJfa8xw==
         (
             SignatureLayer {
                 simple_signing: serde_json::from_value(ss_value.clone()).unwrap(),
+                attestation: None,
                 oci_digest: String::from("digest"),
                 signature: Some(signature),
                 bundle: None,
@@ -1320,6 +1327,7 @@ oXqqo/C9QnOHTto=
 
         SignatureLayer {
             simple_signing: serde_json::from_value(ss_value.clone()).unwrap(),
+            attestation: None,
             oci_digest: String::from(
                 "sha256:5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e",
             ),
@@ -1976,10 +1984,6 @@ JsB89BPhZYch0U0hKANx5TY+ncrm0s8bfJxxHoenAEFhwhuXeb4PqIrtoQ==
         #[rstest]
         #[case::wrong_payload_type(V3BundleMutation::Payload, "unsupported DSSE payloadType")]
         #[case::wrong_statement_type(V3BundleMutation::Statement, "unsupported in-toto _type")]
-        #[case::wrong_predicate_type(
-            V3BundleMutation::Predicate,
-            "unsupported in-toto predicateType"
-        )]
         fn from_sigstore_bundle_rejects_unexpected_types(
             #[case] mutation: V3BundleMutation,
             #[case] expected_error_fragment: &str,

--- a/src/cosign/signature_layers.rs
+++ b/src/cosign/signature_layers.rs
@@ -201,6 +201,18 @@ impl fmt::Display for SignatureLayer {
 }
 
 impl SignatureLayer {
+    /// Returns the in-toto attestation's `predicateType`, if this layer
+    /// carries an attestation.
+    pub fn attestation_predicate_type(&self) -> Option<&str> {
+        self.attestation.as_ref().map(|a| a.predicate_type.as_str())
+    }
+
+    /// Returns the in-toto attestation's `predicate` JSON value, if this
+    /// layer carries an attestation that includes a predicate.
+    pub fn attestation_predicate(&self) -> Option<&serde_json::Value> {
+        self.attestation.as_ref().and_then(|a| a.predicate.as_ref())
+    }
+
     /// Create a [`SignatureLayer`], this function will generate a [`SimpleSigning`]
     /// payload due to the given reference of image and the digest of the manifest.
     /// However, the resulted [`SignatureLayer`] does not have a signature, and it

--- a/src/cosign/verification_constraint/attestation_verifier.rs
+++ b/src/cosign/verification_constraint/attestation_verifier.rs
@@ -1,0 +1,312 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verification constraint for in-toto attestation content.
+
+use super::VerificationConstraint;
+use crate::cosign::signature_layers::SignatureLayer;
+use crate::errors::Result;
+
+/// Verification constraint that checks the in-toto attestation carried inside
+/// a [`SignatureLayer`].
+///
+/// # Relationship to signature verification
+///
+/// This constraint is concerned solely with **content-level** policy on the
+/// attestation (predicate type, predicate contents, etc.).  It does **not**
+/// perform cryptographic signature verification itself.
+///
+/// Signature verification for attestations is split across two stages:
+///
+/// 1. **At `SignatureLayer` construction time**
+///    ([`SignatureLayer::from_sigstore_bundle`]):
+///    - The transparency log entry's Signed Entry Timestamp (SET) and
+///      Merkle inclusion proof are verified against the Rekor public key.
+///    - The tlog body is checked for consistency with the DSSE envelope
+///      (envelope hash, payload hash, signature bytes, and signer
+///      certificate must all match).
+///    - The signing certificate is validated against the Fulcio certificate
+///      pool (if provided), populating `certificate_signature`.
+///
+/// 2. **At constraint evaluation time** (via other
+///    [`VerificationConstraint`] implementations):
+///    - [`PublicKeyVerifier`](super::PublicKeyVerifier) or
+///      [`CertificateVerifier`](super::CertificateVerifier) verify the
+///      DSSE envelope signature against the signer's public key.
+///
+/// In a typical verification flow, `AttestationVerifier` is used
+/// **alongside** a signature-checking constraint (e.g.
+/// `CertificateVerifier`) so that both the cryptographic signature and the
+/// attestation content are validated.
+///
+/// # Checks performed
+///
+/// 1. The [`SignatureLayer`] contains an attestation (i.e. it was produced from
+///    a Sigstore Bundle with a DSSE envelope carrying an in-toto Statement v1).
+/// 2. If [`predicate_type`](Self::predicate_type) is set, the attestation's
+///    `predicateType` must match exactly.
+/// 3. If a [`predicate_validator`](Self::predicate_validator) closure is set,
+///    it is called with the attestation's `predicate` JSON value and must
+///    return `true` for the constraint to be satisfied.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use sigstore::cosign::verification_constraint::AttestationVerifier;
+///
+/// // Require a SLSA provenance attestation with any predicate content.
+/// let verifier = AttestationVerifier::new()
+///     .with_predicate_type("https://slsa.dev/provenance/v1");
+///
+/// // Require a cosign sign attestation and validate the predicate.
+/// let verifier = AttestationVerifier::new()
+///     .with_predicate_type("https://sigstore.dev/cosign/sign/v1")
+///     .with_predicate_validator(|predicate| {
+///         // Custom validation logic on the predicate JSON value.
+///         predicate.is_some()
+///     });
+/// ```
+/// Type alias for the predicate validation closure.
+type PredicateValidatorFn = Box<dyn Fn(Option<&serde_json::Value>) -> bool + Send + Sync>;
+
+pub struct AttestationVerifier {
+    /// If set, the attestation's `predicateType` must match this value.
+    predicate_type: Option<String>,
+    /// If set, this closure is called with the attestation's `predicate` field
+    /// and must return `true` for the constraint to be satisfied.
+    predicate_validator: Option<PredicateValidatorFn>,
+}
+
+impl std::fmt::Debug for AttestationVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// Wrapper so that `Debug` prints without quotes around the value.
+        struct OptionalClosure(bool);
+        impl std::fmt::Debug for OptionalClosure {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                if self.0 {
+                    write!(f, "Some(<closure>)")
+                } else {
+                    write!(f, "None")
+                }
+            }
+        }
+
+        f.debug_struct("AttestationVerifier")
+            .field("predicate_type", &self.predicate_type)
+            .field(
+                "predicate_validator",
+                &OptionalClosure(self.predicate_validator.is_some()),
+            )
+            .finish()
+    }
+}
+
+impl AttestationVerifier {
+    /// Create a new `AttestationVerifier` with no additional constraints.
+    ///
+    /// By default this only checks that an attestation is present on the
+    /// [`SignatureLayer`].
+    pub fn new() -> Self {
+        Self {
+            predicate_type: None,
+            predicate_validator: None,
+        }
+    }
+
+    /// Require the attestation's `predicateType` to match `predicate_type`
+    /// exactly.
+    pub fn with_predicate_type(mut self, predicate_type: &str) -> Self {
+        self.predicate_type = Some(predicate_type.to_string());
+        self
+    }
+
+    /// Supply a closure that validates the attestation's `predicate` field.
+    ///
+    /// Per the [in-toto Statement v1 spec](https://in-toto.io/Statement/v1),
+    /// the predicate is always a JSON object when present.  The closure
+    /// receives `Option<&serde_json::Value>` — `None` when the statement
+    /// omits the `predicate` field entirely, `Some(value)` otherwise.  It
+    /// must return `true` for the constraint to be satisfied.
+    pub fn with_predicate_validator<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Option<&serde_json::Value>) -> bool + Send + Sync + 'static,
+    {
+        self.predicate_validator = Some(Box::new(f));
+        self
+    }
+}
+
+impl Default for AttestationVerifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VerificationConstraint for AttestationVerifier {
+    fn verify(&self, signature_layer: &SignatureLayer) -> Result<bool> {
+        let attestation = match &signature_layer.attestation {
+            Some(a) => a,
+            None => return Ok(false),
+        };
+
+        if let Some(expected) = &self.predicate_type
+            && attestation.predicate_type != *expected
+        {
+            return Ok(false);
+        }
+
+        if let Some(validator) = &self.predicate_validator
+            && !validator(attestation.predicate.as_ref())
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::intoto::{InTotoStatementV1, Subject};
+    use crate::cosign::payload::simple_signing::SimpleSigning;
+    use std::collections::BTreeMap;
+
+    /// Helper to build a minimal `SignatureLayer` with an optional attestation.
+    fn layer_with_attestation(attestation: Option<InTotoStatementV1>) -> SignatureLayer {
+        SignatureLayer {
+            simple_signing: SimpleSigning {
+                critical: crate::cosign::payload::simple_signing::Critical {
+                    identity: crate::cosign::payload::simple_signing::Identity {
+                        docker_reference: String::new(),
+                    },
+                    image: crate::cosign::payload::simple_signing::Image {
+                        docker_manifest_digest: String::new(),
+                    },
+                    type_name: String::new(),
+                },
+                optional: None,
+            },
+            attestation,
+            oci_digest: String::new(),
+            certificate_signature: None,
+            bundle: None,
+            signature: None,
+            raw_data: Vec::new(),
+        }
+    }
+
+    fn sample_attestation(
+        predicate_type: &str,
+        predicate: Option<serde_json::Value>,
+    ) -> InTotoStatementV1 {
+        InTotoStatementV1 {
+            statement_type: "https://in-toto.io/Statement/v1".to_string(),
+            subject: vec![Subject {
+                name: Some("artifact".to_string()),
+                digest: BTreeMap::from([("sha256".to_string(), "abc".to_string())]),
+                annotations: None,
+            }],
+            predicate_type: predicate_type.to_string(),
+            predicate,
+        }
+    }
+
+    #[test]
+    fn rejects_layer_without_attestation() {
+        let verifier = AttestationVerifier::new();
+        let layer = layer_with_attestation(None);
+        assert!(!verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn accepts_layer_with_any_attestation() {
+        let verifier = AttestationVerifier::new();
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://sigstore.dev/cosign/sign/v1",
+            None,
+        )));
+        assert!(verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn accepts_matching_predicate_type() {
+        let verifier =
+            AttestationVerifier::new().with_predicate_type("https://slsa.dev/provenance/v1");
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://slsa.dev/provenance/v1",
+            None,
+        )));
+        assert!(verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn rejects_wrong_predicate_type() {
+        let verifier =
+            AttestationVerifier::new().with_predicate_type("https://slsa.dev/provenance/v1");
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://sigstore.dev/cosign/sign/v1",
+            None,
+        )));
+        assert!(!verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn accepts_when_predicate_validator_returns_true() {
+        let verifier = AttestationVerifier::new().with_predicate_validator(|p| p.is_some());
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://sigstore.dev/cosign/sign/v1",
+            Some(serde_json::json!({"key": "value"})),
+        )));
+        assert!(verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn rejects_when_predicate_validator_returns_false() {
+        let verifier = AttestationVerifier::new().with_predicate_validator(|p| p.is_some());
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://sigstore.dev/cosign/sign/v1",
+            None,
+        )));
+        assert!(!verifier.verify(&layer).unwrap());
+    }
+
+    #[test]
+    fn combined_predicate_type_and_validator() {
+        let verifier = AttestationVerifier::new()
+            .with_predicate_type("https://slsa.dev/provenance/v1")
+            .with_predicate_validator(|p| p.and_then(|v| v.get("builder")).is_some());
+
+        // Correct type + valid predicate → accepted
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://slsa.dev/provenance/v1",
+            Some(serde_json::json!({"builder": {"id": "https://github.com/actions/runner"}})),
+        )));
+        assert!(verifier.verify(&layer).unwrap());
+
+        // Correct type + invalid predicate → rejected
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://slsa.dev/provenance/v1",
+            Some(serde_json::json!({"other": "field"})),
+        )));
+        assert!(!verifier.verify(&layer).unwrap());
+
+        // Wrong type + valid predicate → rejected (type checked first)
+        let layer = layer_with_attestation(Some(sample_attestation(
+            "https://sigstore.dev/cosign/sign/v1",
+            Some(serde_json::json!({"builder": {"id": "https://github.com/actions/runner"}})),
+        )));
+        assert!(!verifier.verify(&layer).unwrap());
+    }
+}

--- a/src/cosign/verification_constraint/cert_subject_email_verifier.rs
+++ b/src/cosign/verification_constraint/cert_subject_email_verifier.rs
@@ -455,6 +455,7 @@ mod tests {
             signature: None,
             bundle: None,
             raw_data: vec![],
+            attestation: None,
         };
 
         // Correct email + correct issuer: must pass

--- a/src/cosign/verification_constraint/certificate_verifier.rs
+++ b/src/cosign/verification_constraint/certificate_verifier.rs
@@ -228,6 +228,7 @@ RAIgPixAn47x4qLpu7Y/d0oyvbnOGtD5cY7rywdMOO7LYRsCIDsCyGUZIYMFfSrt
             bundle: Some(BundleContent::RekorBundle(bundle)),
             certificate_signature: None,
             raw_data: serde_json::to_vec(&ss_value).unwrap(),
+            attestation: None,
         };
 
         (signature_layer, cert_pem_raw)

--- a/src/cosign/verification_constraint/mod.rs
+++ b/src/cosign/verification_constraint/mod.rs
@@ -80,3 +80,6 @@ pub use cert_subject_url_verifier::CertSubjectUrlVerifier;
 
 pub mod annotation_verifier;
 pub use annotation_verifier::AnnotationVerifier;
+
+pub mod attestation_verifier;
+pub use attestation_verifier::AttestationVerifier;


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Sigstore Bundle v0.3 verification previously hard-coded the accepted in-toto `predicateType` to `https://sigstore.dev/cosign/sign/v1`, rejecting bundles with any other predicate type (e.g. SLSA provenance, SBOMs). 

This means images like `ghcr.io/webassembly/wasi/http:0.2.12` — which carry SLSA provenance attestations cab not be verified using this library.

This PR makes three changes:

1. **Removes the predicate type restriction** — replaces `validate_cosign_v1()` with a general `validate()` method that checks only the structural requirements of an in-toto Statement v1 (correct `_type`, at least one subject with a matching digest). Any valid `predicateType` URI is now accepted.

2. **Stores the parsed attestation on `SignatureLayer`** — the in-toto statement was previously parsed, validated, and discarded. It is now retained on the `SignatureLayer` with accessor methods (`attestation_predicate_type()`, `attestation_predicate()`) so users and verification constraints can inspect the attestation content after verification.

3. **Adds `AttestationVerifier` verification constraint** — a new `VerificationConstraint` implementation that lets users express attestation-based policies: require an attestation is present, optionally match a specific `predicateType`, and optionally supply a closure to validate the `predicate` JSON content. Attestation content introspection is left entirely to the user.

All existing cryptographic verification (SET, Merkle inclusion proof, tlog body consistency, certificate validation) is unchanged — this only affects which predicate types are accepted and what attestation data is exposed after verification.

**To test:** verify an image with a non-cosign attestation type:
```sh
cargo run --example verify -- \
  --use-sigstore-tuf-data \
  --predicate-type "https://slsa.dev/provenance/v1" \
  ghcr.io/webassembly/wasi/http:0.2.12
```

closes #588

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Added support for verifying Sigstore Bundle v0.3 attestations with arbitrary in-toto predicate types.

 Parsed in-toto attestation is now stored on `SignatureLayer` and accessible via `attestation_predicate_type()` and `attestation_predicate()`.

**Compatibility note:** `trusted_signature_layers()` may now return additional `SignatureLayer` objects for bundles with non-cosign predicate types that were previously silently rejected. 

Users who were implicitly relying on only `cosign/sign/v1` layers being returned should add an `AttestationVerifier` constraint with `.with_predicate_type("https://sigstore.dev/cosign/sign/v1")` to restore the previous filtering behavior.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

 Users can reference the `AttestationVerifier` rustdoc and the updated `examples/cosign/verify` example for usage.


